### PR TITLE
Fix error detecting version and testing workflow

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt export-subst

--- a/.github/workflows/test_package_build.yml
+++ b/.github/workflows/test_package_build.yml
@@ -40,6 +40,18 @@ jobs:
         with:
           name: archive
           path: archive/
+      - name: Download test data
+        env:
+          BOX_USERNAME: ${{ secrets.BOX_USERNAME }}
+          BOX_PASSWORD: ${{ secrets.BOX_PASSWORD }}
+        run: |
+          python tests/download_test_data.py
+          tree tests/test_data
+      - name: Upload test data artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: test_data
+          path: tests/test_data/downloaded
   test-package:
     runs-on: ubuntu-latest
     needs: [build]
@@ -83,13 +95,11 @@ jobs:
       - name: Install editable
         if: matrix.package == 'editable'
         run: pip install -e .
-      - name: Download test data
-        env:
-          BOX_USERNAME: ${{ secrets.BOX_USERNAME }}
-          BOX_PASSWORD: ${{ secrets.BOX_PASSWORD }}
-        run: |
-          python tests/download_test_data.py
-          tree tests/test_data
+      - name: Download test data artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: test_data
+          path: tests/test_data/downloaded
       - name: Run tests without coverage
         if: matrix.package != 'editable'
         run: |

--- a/.github/workflows/test_package_build.yml
+++ b/.github/workflows/test_package_build.yml
@@ -18,28 +18,37 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repo
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: 3
-      - run: pip install --upgrade build twine
+
       - name: Build sdist and wheel
-        run: python -m build
-      - run: twine check dist/*
+        run: |
+          pip install --upgrade build twine
+          python -m build
+          twine check dist/*
+
       - name: Upload sdist and wheel artifacts
         uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
+
       - name: Build git archive
         run: mkdir archive && git archive -v -o archive/archive.tgz HEAD
+
       - name: Upload git archive artifact
         uses: actions/upload-artifact@v4
         with:
           name: archive
           path: archive/
+
       - name: Download test data
         env:
           BOX_USERNAME: ${{ secrets.BOX_USERNAME }}
@@ -47,11 +56,13 @@ jobs:
         run: |
           python tests/download_test_data.py
           tree tests/test_data
+
       - name: Upload test data artifact
         uses: actions/upload-artifact@v4
         with:
           name: test_data
           path: tests/test_data/downloaded
+
   test-package:
     runs-on: ubuntu-latest
     needs: [build]
@@ -59,64 +70,79 @@ jobs:
       matrix:
         package: ['wheel', 'sdist', 'archive', 'editable']
     steps:
+      - name: Checkout repo
+        # Used to access the tests. Only install from source if matrix.package == 'editable'.
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Download sdist and wheel artifacts
-        if: matrix.package != 'archive'
+        if: matrix.package == 'wheel' || matrix.package == 'sdist'
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
+
       - name: Download git archive artifact
         if: matrix.package == 'archive'
         uses: actions/download-artifact@v4
         with:
           name: archive
           path: archive/
-      - name: Checkout repo
-        if: matrix.package == 'editable'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
+
       - name: Update pip
         run: pip install --upgrade pip
+
       - name: Install wheel
         if: matrix.package == 'wheel'
         run: pip install dist/*.whl
+
       - name: Install sdist
         if: matrix.package == 'sdist'
         run: pip install dist/*.tar.gz
+
       - name: Install archive
         if: matrix.package == 'archive'
         run: pip install archive/archive.tgz
+
       - name: Install editable
         if: matrix.package == 'editable'
         run: pip install -e .
+
       - name: Download test data artifact
         uses: actions/download-artifact@v4
         with:
           name: test_data
           path: tests/test_data/downloaded
+
       - name: Run tests without coverage
         if: matrix.package != 'editable'
         run: |
           pip install pytest
           pip list
           pytest -v
+
       - name: Run tests on editable install with coverage
         if: matrix.package == 'editable'
         run: |
           pip install pytest-cov
           pip list
           pytest --cov=src --cov-report=xml --cov-report=term -v
+
       - name: Upload coverage reports to Codecov
         if: matrix.package == 'editable'
         uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   # pypi-publish:
   #   name: Upload release to PyPI
   #   runs-on: ubuntu-latest

--- a/.github/workflows/test_package_build.yml
+++ b/.github/workflows/test_package_build.yml
@@ -105,13 +105,13 @@ jobs:
         run: |
           pip install pytest
           pip list
-          pytest -v jdb_to_nwb
+          pytest -v
       - name: Run tests on editable install with coverage
         if: matrix.package == 'editable'
         run: |
           pip install pytest-cov
           pip list
-          pytest --cov=src --cov-report=xml -v jdb_to_nwb
+          pytest --cov=src --cov-report=xml --cov-report=term -v
       - name: Upload coverage reports to Codecov
         if: matrix.package == 'editable'
         uses: codecov/codecov-action@v5

--- a/.github/workflows/test_package_build.yml
+++ b/.github/workflows/test_package_build.yml
@@ -83,8 +83,6 @@ jobs:
       - name: Install editable
         if: matrix.package == 'editable'
         run: pip install -e .
-      - name: Install test extras
-        run: pip install .[test]
       - name: Download test data
         env:
           BOX_USERNAME: ${{ secrets.BOX_USERNAME }}
@@ -94,10 +92,16 @@ jobs:
           tree tests/test_data
       - name: Run tests without coverage
         if: matrix.package != 'editable'
-        run: pytest -v jdb_to_nwb
+        run: |
+          pip install pytest
+          pip list
+          pytest -v jdb_to_nwb
       - name: Run tests on editable install with coverage
         if: matrix.package == 'editable'
-        run: pytest --cov=src --cov-report=xml -v jdb_to_nwb
+        run: |
+          pip install pytest-cov
+          pip list
+          pytest --cov=src --cov-report=xml -v jdb_to_nwb
       - name: Upload coverage reports to Codecov
         if: matrix.package == 'editable'
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ jdb_to_nwb = "jdb_to_nwb.convert:cli"
 
 [tool.hatch.version]
 source = "vcs"
-fallback_version = "0.1.0.dev0"
+fallback-version = "0.1.0.dev0"
 
 [tool.hatch.build.hooks.vcs]
 # this file is created/updated when the package is installed and used in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ jdb_to_nwb = "jdb_to_nwb.convert:cli"
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.1.0.dev0"
 
 [tool.hatch.build.hooks.vcs]
 # this file is created/updated when the package is installed and used in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ jdb_to_nwb = "jdb_to_nwb.convert:cli"
 
 [tool.hatch.version]
 source = "vcs"
+fallback_version = "0.1.0.dev0"
 
 [tool.hatch.build.hooks.vcs]
 # this file is created/updated when the package is installed and used in

--- a/src/jdb_to_nwb/__init__.py
+++ b/src/jdb_to_nwb/__init__.py
@@ -1,0 +1,1 @@
+from ._version import __version__

--- a/tests/download_test_data.py
+++ b/tests/download_test_data.py
@@ -21,13 +21,15 @@ def main():
     # Create test data directory if it doesn't exist
     test_data_dir.mkdir(parents=True, exist_ok=True)
 
-    # Read .env file and parse variables into environment variables 
-    with open('.env', 'r') as f:
-        for line in f:
-            # Skip empty lines and comments
-            if line.strip() and not line.startswith('#'):
-                key, value = line.strip().split('=', 1)
-                os.environ[key] = value
+    # Read .env file if present and parse variables into environment variables
+    env_file_path = ".env"
+    if os.path.exists(env_file_path):
+        with open(env_file_path, 'r') as f:
+            for line in f:
+                # Skip empty lines and comments
+                if line.strip() and not line.startswith('#'):
+                    key, value = line.strip().split('=', 1)
+                    os.environ[key] = value
 
     # Get Box credentials
     box_username = os.environ.get('BOX_USERNAME')


### PR DESCRIPTION
The latest run has an error getting the version from source `vcs`. Fixing that resulted in errors finding the test data and the tests. This PR resolves those issues.