### PR TITLE
Reorganize photometry code

### DIFF
--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -32,7 +32,8 @@ def read_phot_data(phot_file_path):
         phot["date"] = fid.read(256).decode("utf-8").strip("\x00")
         phot["time"] = fid.read(256).decode("utf-8").strip("\x00")
 
-        # Loop through the four channels and extract the location, signal, frequency, max and min values in the same way
+        # Loop through the four channels and extract the 
+        # location, signal, frequency, max and min values in the same way
         phot["channels"] = []
 
         # Initialize a list of empty dictionaries for the channels
@@ -211,8 +212,8 @@ def run_lockin_detection(phot):
 
     loc = phot["channels"][2]["location"][:15]  # First 15 characters of the location
 
-    # Create a dictionary with the relevant signals to match signals.mat returned by the original MATLAB processing code
-    # NOTE: We don't actually use sig2 and ref2 - these may be removed in a future PR but are kept for posterity for now
+    # Create a dict with the relevant signals to match signals.mat returned by the original MATLAB processing code
+    # NOTE: We don't use sig2 and ref2 - these may be removed in a future PR but are kept for posterity for now
     signals = {"sig1": sig1, "ref": ref, "sig2": sig2, "ref2": ref2, "loc": loc}
     return signals
 
@@ -253,7 +254,8 @@ def whittaker_smooth(data, binary_mask, lambda_):
 
     Args:
     data: 1D array representing the signal data
-    binary_mask: binary mask indicating which points are signals (peaks) and which are background (0 = signal/peak, 1=background)
+    binary_mask: binary mask indicating which points are signals (peaks) and which are background 
+    (0 = signal/peak, 1=background)
     lambda_: Smoothing parameter. A larger value results in a smoother baseline.
 
     Returns:
@@ -305,24 +307,25 @@ def airPLS(data, lambda_=1e8, max_iterations=50):
     for i in range(1, max_iterations + 1):
         # Use Whittaker smoothing to fit a baseline to the data using the updated weights
         baseline = whittaker_smooth(data, weights, lambda_)
-        # Difference between data and baseline to calculate residuals. delta > 0 == peak. delta < 0 == background.
+        # Difference between data and baseline to calculate residuals. delta > 0 == peak, delta < 0 == background
         delta = data - baseline
         # Calculate how much data is below the baseline
         sum_of_neg_deltas = np.abs(delta[delta < 0].sum())
 
-        # Convergence check: if sum_of_neg_deltas < 0.1% of the total data, or if the maximum number of iterations is reached
+        # Convergence check: if sum_of_neg_deltas < 0.1% of the total data, or if max iterations is reached
         if sum_of_neg_deltas < 0.001 * (abs(data)).sum() or i == max_iterations:
             if i == max_iterations:
                 warnings.warn(
                     f"Reached maximum iterations before convergence was achieved! "
-                    f"Wanted sum_of_neg_deltas < {0.001 * (abs(data)).sum()}, got sum_of_neg_deltas = {sum_of_neg_deltas}"
+                    f"Wanted sum_of_neg_deltas < {0.001 * (abs(data)).sum()}, "
+                    f"got sum_of_neg_deltas = {sum_of_neg_deltas}"
                 )
             break
         # Delta >= 0 means that this point is part of a peak, so its weight is set to 0 in order to ignore it
         weights[delta >= 0] = 0
-        # Updates the weights for the negative deltas. Gives more weight to larger residuals using an exponential function.
+        # Update weights for the negative deltas. Gives more weight to larger residuals using an exponential
         weights[delta < 0] = np.exp(i * np.abs(delta[delta < 0]) / sum_of_neg_deltas)
-        # Updates the weights for the first and last data points to ensure edges of data are not ignored or underweighed.
+        # Update weights for the first and last data points to ensure edges of data are not ignored or underweighed
         weights[0] = np.exp(i * (delta[delta < 0]).max() / sum_of_neg_deltas)
         weights[-1] = weights[0]
     return baseline
@@ -711,7 +714,8 @@ def add_photometry(nwbfile: NWBFile, metadata: dict):
     else:
         raise ValueError(
             "None of the required photometry subfields exist in the metadata dictionary.\n"
-            "If you are using LabVIEW, you must include both 'phot_file_path' and 'box_file_path' to process raw LabVIEW data,\n"
+            "If you are using LabVIEW, you must include both 'phot_file_path' and 'box_file_path' "
+            "to process raw LabVIEW data,\n"
             "OR 'signals_mat_file_path' if the initial preprocessing has already been done in MATLAB.\n"
             "If you are using pyPhotometry, you must include 'ppd_file_path'."
         )

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -519,7 +519,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     )
 
     raw_ratio_response_series = FiberPhotometryResponseSeries(
-        name="raw_470/405",
+        name="raw_470_405_ratio",
         description="Raw ratiometric index of 470nm and 405nm",
         data=relative_raw_signal.to_numpy(),
         unit="V",
@@ -527,7 +527,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     )
 
     z_scored_ratio_response_series = FiberPhotometryResponseSeries(
-        name="zscored_470/405",
+        name="zscored_470_405_ratio",
         description="Z-scored ratiometric index of 470nm and 405nm",
         data=ratio_zscored,
         unit="z-score",

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -274,7 +274,7 @@ def whittaker_smooth(data, binary_mask, lambda_):
     the fitted background vector
     """
 
-    data_matrix = np.matrix(data)
+    data_matrix = np.array(data)
     data_size = data_matrix.size  # Size of the data matrix
     # Create an identity matrix the size of the data matrix in compressed sparse column (csc) format
     identity_matrix = eye(data_size, format="csc")

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -274,7 +274,7 @@ def whittaker_smooth(data, binary_mask, lambda_):
     the fitted background vector
     """
 
-    data_matrix = np.array(data).reshape(-1, 1)
+    data_matrix = np.matrix(data)
     data_size = data_matrix.size  # Size of the data matrix
     # Create an identity matrix the size of the data matrix in compressed sparse column (csc) format
     identity_matrix = eye(data_size, format="csc")
@@ -468,7 +468,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     ratio_zscored = np.divide(np.subtract(ratio_highpass,ratio_highpass.mean()),ratio_highpass.std())
 
     # Add photometry signals to the NWB
-    print("Adding photometry signals to NWB ...")
+    print("Adding photometry signals to NWB...")
 
     raw_470_response_series = FiberPhotometryResponseSeries(
         name="raw_470",

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -274,7 +274,7 @@ def whittaker_smooth(data, binary_mask, lambda_):
     the fitted background vector
     """
 
-    data_matrix = np.array(data)
+    data_matrix = np.array(data).reshape(-1, 1)
     data_size = data_matrix.size  # Size of the data matrix
     # Create an identity matrix the size of the data matrix in compressed sparse column (csc) format
     identity_matrix = eye(data_size, format="csc")

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -473,7 +473,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     raw_470_response_series = FiberPhotometryResponseSeries(
         name="raw_470",
         description="Raw 470 nm",
-        data=raw_green.T[0],
+        data=raw_green.to_numpy(),
         unit="V",
         rate=float(sampling_rate),
     )
@@ -481,7 +481,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     z_scored_470_response_series = FiberPhotometryResponseSeries(
         name="z_scored_470",
         description="Z-scored 470 nm",
-        data=green_zscored.T[0],
+        data=green_zscored.to_numpy(),
         unit="z-score",
         rate=float(sampling_rate),
     )
@@ -489,7 +489,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     raw_405_response_series = FiberPhotometryResponseSeries(
         name="raw_405",
         description="Raw 405 nm",
-        data=raw_405.T[0],
+        data=raw_405.to_numpy(),
         unit="V",
         rate=float(sampling_rate),
     )
@@ -497,7 +497,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     z_scored_405_response_series = FiberPhotometryResponseSeries(
         name="zscored_405",
         description="Z-scored 405nm. This is used to calculate the ratiometric index when using GRAB-ACh3.8",
-        data=zscored_405.T[0],
+        data=zscored_405.to_numpy(),
         unit="z-score",
         rate=float(sampling_rate),
     )
@@ -505,7 +505,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     raw_565_response_series = FiberPhotometryResponseSeries(
         name="raw_565",
         description="Raw 565 nm",
-        data=raw_red.T[0],
+        data=raw_red.to_numpy(),
         unit="V",
         rate=float(sampling_rate),
     )
@@ -513,7 +513,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     z_scored_565_response_series = FiberPhotometryResponseSeries(
         name="zscored_565",
         description="Z-scored 565nm",
-        data=red_zscored.T[0],
+        data=red_zscored.to_numpy(),
         unit="z-score",
         rate=float(sampling_rate),
     )
@@ -521,7 +521,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     raw_ratio_response_series = FiberPhotometryResponseSeries(
         name="raw_470/405",
         description="Raw ratiometric index of 470nm and 405nm",
-        data=relative_raw_signal.T[0],
+        data=relative_raw_signal.to_numpy(),
         unit="V",
         rate=float(sampling_rate),
     )
@@ -529,7 +529,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     z_scored_ratio_response_series = FiberPhotometryResponseSeries(
         name="zscored_470/405",
         description="Z-scored ratiometric index of 470nm and 405nm",
-        data=ratio_zscored.T[0],
+        data=ratio_zscored.to_numpy(),
         unit="z-score",
         rate=float(sampling_rate),
     )

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -481,7 +481,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     z_scored_470_response_series = FiberPhotometryResponseSeries(
         name="z_scored_470",
         description="Z-scored 470 nm",
-        data=green_zscored.to_numpy(),
+        data=green_zscored,
         unit="z-score",
         rate=float(sampling_rate),
     )
@@ -497,7 +497,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     z_scored_405_response_series = FiberPhotometryResponseSeries(
         name="zscored_405",
         description="Z-scored 405nm. This is used to calculate the ratiometric index when using GRAB-ACh3.8",
-        data=zscored_405.to_numpy(),
+        data=zscored_405,
         unit="z-score",
         rate=float(sampling_rate),
     )
@@ -513,7 +513,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     z_scored_565_response_series = FiberPhotometryResponseSeries(
         name="zscored_565",
         description="Z-scored 565nm",
-        data=red_zscored.to_numpy(),
+        data=red_zscored,
         unit="z-score",
         rate=float(sampling_rate),
     )
@@ -529,7 +529,7 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     z_scored_ratio_response_series = FiberPhotometryResponseSeries(
         name="zscored_470/405",
         description="Z-scored ratiometric index of 470nm and 405nm",
-        data=ratio_zscored.to_numpy(),
+        data=ratio_zscored,
         unit="z-score",
         rate=float(sampling_rate),
     )

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -436,9 +436,8 @@ def process_and_add_pyphotometry_to_nwb(nwbfile: NWBFile, ppd_file_path):
     analog_3: 405 nm (for ratiometric correction of gACh)
     """
     ppd_data = import_ppd(ppd_file_path)  
-
     raw_green = pd.Series(ppd_data['analog_1'])
-    raw_red = pd.Series(ppd_data ['analog_2'])
+    raw_red = pd.Series(ppd_data['analog_2'])
     raw_405 = pd.Series(ppd_data['analog_3'])
     relative_raw_signal = raw_green / raw_405
 

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -693,7 +693,7 @@ def add_photometry(nwbfile: NWBFile, metadata: dict):
 
     if "photometry" not in metadata:
         print("No photometry metadata found for this session. Skipping photometry conversion.")
-        return None
+        return None, None
 
     # Add photometry metadata to the NWB
     print("Adding photometry metadata to NWB ...")

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -10,21 +10,7 @@ from scipy.signal import butter, lfilter, hilbert, filtfilt
 from scipy.sparse import diags, eye, csc_matrix
 from scipy.sparse.linalg import spsolve
 from sklearn.linear_model import Lasso
-
-# Some of these imports are unused for now but will be used for photometry metadata
-from ndx_fiber_photometry import (
-    Indicator,
-    OpticalFiber,
-    ExcitationSource,
-    Photodetector,
-    DichroicMirror,
-    BandOpticalFilter,
-    EdgeOpticalFilter,
-    FiberPhotometry,
-    FiberPhotometryTable,
-    FiberPhotometryResponseSeries,
-    CommandedVoltageSeries,
-)
+from ndx_fiber_photometry import FiberPhotometryResponseSeries
 
 
 def read_phot_data(phot_file_path):

--- a/tests/download_test_data.py
+++ b/tests/download_test_data.py
@@ -9,17 +9,24 @@ from pathlib import Path
 
 
 def main():
-    # This path is relative to the root of the user's Box account
-    remote_dir_to_download = "/nwb-test-data/IM-1478/07252022"
+    # These paths are relative to the root of the user's Box account
+    remote_dirs_to_download = [
+        "/nwb-test-data/IM-1478/07252022",
+        "/nwb-test-data/IM-1770_corvette/11062024"
+        ]
 
     # List of file extensions to exclude from the download
     exclude_files = [".dat"]
 
-    # This is the directory where the downloaded data will be saved
-    test_data_dir = Path('tests/test_data/downloaded/IM-1478/07252022')
+    # These are the directories where the downloaded data will be saved
+    test_data_directories = [
+        Path('tests/test_data/downloaded/IM-1478/07252022'),
+        Path('tests/test_data/downloaded/IM-1770_corvette/11062024')
+        ]
 
-    # Create test data directory if it doesn't exist
-    test_data_dir.mkdir(parents=True, exist_ok=True)
+    # Create each test data directory if it doesn't exist
+    for test_data_dir in test_data_directories:
+        test_data_dir.mkdir(parents=True, exist_ok=True)
 
     # Read .env file if present and parse variables into environment variables
     env_file_path = ".env"
@@ -90,8 +97,9 @@ def main():
         ftps.cwd(original_dir)
 
     # Start recursive download from current directory
-    print(f"Starting recursive download from {remote_dir_to_download} to {test_data_dir}...")
-    download_recursively(ftps, remote_dir_to_download, test_data_dir)
+    for remote_dir_to_download, test_data_dir in zip(remote_dirs_to_download, test_data_directories):
+        print(f"Starting recursive download from {remote_dir_to_download} to {test_data_dir}...")
+        download_recursively(ftps, remote_dir_to_download, test_data_dir)
 
     # Close the connection
     ftps.quit()

--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -254,11 +254,8 @@ def test_add_photometry_from_pyphotometry():
         ), f"{series_name} has a sampling rate of {getattr(nwbfile.acquisition[series_name], 'rate', None)}, expected {expected_sampling_rate}"
         
     # Check that the photometry series in the nwbfile match the expected signals from the reference dataframe
-    #nwb_signal_names = ["raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470_405_ratio", "zscored_470_405_ratio"]
-    #reference_signal_names = ["raw_green", "filtered_green", "raw_405", "filtered_405", "raw_red", "filtered_red", "raw 470/405", "filtered_ratio"]
-    # TODO: Remove filtered signals from comparison for now - check how reference data was processed
-    nwb_signal_names = ["raw_470", "raw_405", "raw_565", "raw_470_405_ratio"]
-    reference_signal_names = ["raw_green",  "raw_405",  "raw_red", "raw 470/405"]
+    nwb_signal_names = ["raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470_405_ratio", "zscored_470_405_ratio"]
+    reference_signal_names = ["raw_green", "green_z_scored", "raw_405", "z_scored_405", "raw_red", "red_z_scored", "raw 470/405", "ratio_z_scored"]
 
     # Compare each signal in the nwbfile to its respective reference
     for sig_name, ref_name in zip(nwb_signal_names, reference_signal_names):

--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -254,8 +254,8 @@ def test_add_photometry_from_pyphotometry():
         ), f"{series_name} has a sampling rate of {getattr(nwbfile.acquisition[series_name], 'rate', None)}, expected {expected_sampling_rate}"
         
     # Check that the photometry series in the nwbfile match the expected signals from the reference dataframe
-    nwb_signal_names = ["raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470_405_ratio"] # add "zscored_470_405_ratio"
-    reference_signal_names = ["raw_green", "green_z_scored", "raw_405", "z_scored_405", "raw_red", "red_z_scored", "raw 470/405"] # add "ratio_z_scored"
+    nwb_signal_names = ["raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470_405_ratio", "zscored_470_405_ratio"]
+    reference_signal_names = ["raw_green", "green_z_scored", "raw_405", "z_scored_405", "raw_red", "red_z_scored", "raw 470/405", "ratio_z_scored"]
 
     # Compare each signal in the nwbfile to its respective reference
     for sig_name, ref_name in zip(nwb_signal_names, reference_signal_names):

--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -11,7 +11,10 @@ from jdb_to_nwb.convert_photometry import add_photometry, process_raw_labview_ph
 
 
 def test_process_raw_labview_photometry_signals():
-    """Test that the process_raw_labview_photometry_signals function returns a signals dictionary equivalent to signals.mat."""
+    """
+    Test that the process_raw_labview_photometry_signals function 
+    returns a signals dictionary equivalent to signals.mat.
+    """
 
     # Create a test metadata dictionary
     test_data_dir = Path("tests/test_data/downloaded/IM-1478/07252022")
@@ -47,23 +50,37 @@ def test_process_raw_labview_photometry_signals():
     # In our former MATLAB photometry preprocessing pipeline (used to create signals.mat), we would sometimes
     # remove a certain number of samples from the beginning of our signals for alignment with behavior.
     # In this new pipeline, we do this alignment later so this is no longer necessary at this step.
-    # This results in the signals in our created signals dict being longer than the signals in the reference signals.mat,
+    # This results in the signals in our created dict being longer than the reference signals in signals.mat,
     # so we calculate the number of samples to remove from the beginning so we can do comparisons.
     samples_removed_from_reference = len(signals["ref"]) - len(reference_signals_mat["ref"].flatten())
 
-    # The difference between our created signal and the reference from signals.mat must be <0.01% of the magnitude of the reference
-    assert np.allclose(signals["ref"][samples_removed_from_reference:], reference_signals_mat["ref"].flatten(), rtol=1e-4)
-    assert np.allclose(signals["sig1"][samples_removed_from_reference:], reference_signals_mat["sig1"].flatten(), rtol=1e-4)
-    # We allow an additional absolute tolerance for sig2 because there are some values very close to 0 where relative tolerance is less useful
-    # (Also, we don't use actually sig2 so it doesn't really matter)
-    assert np.allclose(signals["sig2"][samples_removed_from_reference:], reference_signals_mat["sig2"].flatten(), rtol=1e-4, atol=5)
+    # The difference between our signal and the reference must be <0.01% of the magnitude of the reference
+    assert np.allclose(
+        signals["ref"][samples_removed_from_reference:], 
+        reference_signals_mat["ref"].flatten(), 
+        rtol=1e-4
+    )
+    assert np.allclose(
+        signals["sig1"][samples_removed_from_reference:], 
+        reference_signals_mat["sig1"].flatten(), 
+        rtol=1e-4
+    )
+    # We allow an additional absolute tolerance for sig2 because there are some values very close to 0 
+    # where relative tolerance is less useful. (Also, we don't use actually sig2 so it doesn't really matter)
+    assert np.allclose(
+        signals["sig2"][samples_removed_from_reference:], 
+        reference_signals_mat["sig2"].flatten(), 
+        rtol=1e-4, 
+        atol=5
+    )
 
 
 def test_add_photometry_from_signals_mat():
     """
     Test that the add_photometry function results in the expected FiberPhotometryResponseSeries.
 
-    This version of the test uses the already created signals.mat at "signals_mat_file_path" to further process and add photometry signals to the NWB.
+    This version of the test uses the already created signals.mat at "signals_mat_file_path" 
+    to further process and add photometry signals to the NWB.
     """
 
     # Create a test metadata dictionary with preprocessed LabVIEW data ("signals_mat_file_path")
@@ -89,9 +106,10 @@ def test_add_photometry_from_signals_mat():
     # Define the FiberPhotometryResponseSeries we expect to have been added to the nwbfile
     expected_photometry_series = {"raw_green", "raw_reference", "z_scored_green_dFF", "z_scored_reference_fitted"}
     expected_sampling_rate = 250  # Hz
-    
+
     # Assert that we have returned the correct sampling rate
-    assert sampling_rate == expected_sampling_rate, f"Expected sampling rate {expected_sampling_rate} Hz, got {sampling_rate} Hz"
+    assert sampling_rate == expected_sampling_rate, (
+        f"Expected sampling rate {expected_sampling_rate} Hz, got {sampling_rate} Hz")
 
     # Assert that all expected photometry series are present in the acquisition field of the nwbfile
     actual_photometry_series = set(nwbfile.acquisition.keys())
@@ -101,11 +119,15 @@ def test_add_photometry_from_signals_mat():
     # Check the basic attributes of each series
     for series_name in expected_photometry_series:
         # Assert that all series are of type FiberPhotometryResponseSeries
-        assert isinstance(nwbfile.acquisition[series_name], FiberPhotometryResponseSeries), f"{series_name} is not of type FiberPhotometryResponseSeries"
+        assert isinstance(nwbfile.acquisition[series_name], FiberPhotometryResponseSeries), (
+            f"{series_name} is not of type FiberPhotometryResponseSeries")
         # Assert all series have a sampling rate of 250 Hz
         assert (
             getattr(nwbfile.acquisition[series_name], "rate", None) == expected_sampling_rate
-        ), f"{series_name} has a sampling rate of {getattr(nwbfile.acquisition[series_name], 'rate', None)}, expected {expected_sampling_rate}"
+        ), (
+            f"{series_name} has a sampling rate of {getattr(nwbfile.acquisition[series_name], 'rate', None)}, "
+            f"expected {expected_sampling_rate}"
+        )
 
     # Check that the photometry series in the nwbfile match the expected signals from the reference dataframe
     green_z_scored_dFF = np.array(nwbfile.acquisition["z_scored_green_dFF"].data)
@@ -159,9 +181,10 @@ def test_add_photometry_from_raw_labview():
     # Define the FiberPhotometryResponseSeries we expect to have been added to the nwbfile
     expected_photometry_series = {"raw_green", "raw_reference", "z_scored_green_dFF", "z_scored_reference_fitted"}
     expected_sampling_rate = 250  # Hz
-    
+
     # Assert that we have returned the correct sampling rate
-    assert sampling_rate == expected_sampling_rate, f"Expected sampling rate {expected_sampling_rate} Hz, got {sampling_rate} Hz"
+    assert sampling_rate == expected_sampling_rate, (
+        f"Expected sampling rate {expected_sampling_rate} Hz, got {sampling_rate} Hz")
 
     # Assert that all expected photometry series are present in the acquisition field of the nwbfile
     actual_photometry_series = set(nwbfile.acquisition.keys())
@@ -171,20 +194,24 @@ def test_add_photometry_from_raw_labview():
     # Check the basic attributes of each series
     for series_name in expected_photometry_series:
         # Assert that all series are of type FiberPhotometryResponseSeries
-        assert isinstance(nwbfile.acquisition[series_name], FiberPhotometryResponseSeries), f"{series_name} is not of type FiberPhotometryResponseSeries"
+        assert isinstance(nwbfile.acquisition[series_name], FiberPhotometryResponseSeries), (
+            f"{series_name} is not of type FiberPhotometryResponseSeries")
         # Assert all series have a sampling rate of 250 Hz
         assert (
             getattr(nwbfile.acquisition[series_name], "rate", None) == expected_sampling_rate
-        ), f"{series_name} has a sampling rate of {getattr(nwbfile.acquisition[series_name], 'rate', None)}, expected {expected_sampling_rate}"
+        ), (
+            f"{series_name} has a sampling rate of {getattr(nwbfile.acquisition[series_name], 'rate', None)}, "
+            f"expected {expected_sampling_rate}"
+        )
 
     # Check that the photometry series in the nwbfile match the expected signals from the reference dataframe
     green_z_scored_dFF = np.array(nwbfile.acquisition["z_scored_green_dFF"].data)
     green_z_scored_dFF_reference = reference_dataframe["green"].values
 
-    # In our former MATLAB photometry preprocessing pipeline (used to create the reference dataframe), we would sometimes
-    # remove a certain number of samples from the beginning of our signals for alignment with behavior.
+    # In our former MATLAB photometry preprocessing pipeline (used to create the reference dataframe), 
+    # we would sometimes remove some samples from the beginning of our signals for alignment with behavior.
     # In this new pipeline, we do this alignment later so this is no longer necessary at this step.
-    # This results in the signals in our created signals dict being longer than the signals in the reference dataframe,
+    # This results in the signals in our created dict being longer than the reference signals in the dataframe,
     # so we calculate the number of samples to remove from the beginning so we can do comparisons.
     samples_removed_from_reference = len(green_z_scored_dFF) - len(green_z_scored_dFF_reference)
     green_z_scored_dFF = green_z_scored_dFF[samples_removed_from_reference:]
@@ -233,11 +260,13 @@ def test_add_photometry_from_pyphotometry():
     sampling_rate, visits = add_photometry(nwbfile=nwbfile, metadata=metadata)
 
     # Define the FiberPhotometryResponseSeries we expect to have been added to the nwbfile
-    expected_photometry_series = {"raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470_405_ratio", "zscored_470_405_ratio"}
+    expected_photometry_series = {"raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", 
+                                  "zscored_565", "raw_470_405_ratio", "zscored_470_405_ratio"}
     expected_sampling_rate = 86 # Hz
-    
+
     # Assert that we have returned the correct sampling rate
-    assert sampling_rate == expected_sampling_rate, f"Expected sampling rate {expected_sampling_rate} Hz, got {sampling_rate} Hz"
+    assert sampling_rate == expected_sampling_rate, (
+        f"Expected sampling rate {expected_sampling_rate} Hz, got {sampling_rate} Hz")
 
     # Assert that all expected photometry series are present in the acquisition field of the nwbfile
     actual_photometry_series = set(nwbfile.acquisition.keys())
@@ -247,15 +276,21 @@ def test_add_photometry_from_pyphotometry():
     # Check the basic attributes of each series
     for series_name in expected_photometry_series:
         # Assert that all series are of type FiberPhotometryResponseSeries
-        assert isinstance(nwbfile.acquisition[series_name], FiberPhotometryResponseSeries), f"{series_name} is not of type FiberPhotometryResponseSeries"
+        assert isinstance(nwbfile.acquisition[series_name], FiberPhotometryResponseSeries), (
+            f"{series_name} is not of type FiberPhotometryResponseSeries")
         # Assert all series have a sampling rate of 86 Hz
         assert (
             getattr(nwbfile.acquisition[series_name], "rate", None) == expected_sampling_rate
-        ), f"{series_name} has a sampling rate of {getattr(nwbfile.acquisition[series_name], 'rate', None)}, expected {expected_sampling_rate}"
+        ), (
+            f"{series_name} has a sampling rate of {getattr(nwbfile.acquisition[series_name], 'rate', None)}, "
+            f"expected {expected_sampling_rate}"
+        )
         
     # Check that the photometry series in the nwbfile match the expected signals from the reference dataframe
-    nwb_signal_names = ["raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470_405_ratio", "zscored_470_405_ratio"]
-    reference_signal_names = ["raw_green", "green_z_scored", "raw_405", "z_scored_405", "raw_red", "red_z_scored", "raw 470/405", "ratio_z_scored"]
+    nwb_signal_names = ["raw_470", "z_scored_470", "raw_405", "zscored_405", 
+                        "raw_565", "zscored_565", "raw_470_405_ratio", "zscored_470_405_ratio"]
+    reference_signal_names = ["raw_green", "green_z_scored", "raw_405", "z_scored_405", 
+                              "raw_red", "red_z_scored", "raw 470/405", "ratio_z_scored"]
 
     # Compare each signal in the nwbfile to its respective reference
     for sig_name, ref_name in zip(nwb_signal_names, reference_signal_names):
@@ -322,5 +357,7 @@ def test_add_photometry_with_incomplete_metadata(capsys):
     except ValueError as e:
         assert str(e).startswith("None of the required photometry subfields exist in the metadata dictionary")
     else:
-        assert False, "Expected ValueError was not raised in response to missing photometry subfields in the metadata dict."
-        
+        assert False, (
+            "Expected ValueError was not raised in response to "
+            "missing photometry subfields in the metadata dict."
+        )

--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -254,8 +254,11 @@ def test_add_photometry_from_pyphotometry():
         ), f"{series_name} has a sampling rate of {getattr(nwbfile.acquisition[series_name], 'rate', None)}, expected {expected_sampling_rate}"
         
     # Check that the photometry series in the nwbfile match the expected signals from the reference dataframe
-    nwb_signal_names = ["raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470_405_ratio", "zscored_470_405_ratio"]
-    reference_signal_names = ["raw_green", "filtered_green", "raw_405", "filtered_405", "raw_red", "filtered_red", "raw 470/405", "filtered_ratio"]
+    #nwb_signal_names = ["raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470_405_ratio", "zscored_470_405_ratio"]
+    #reference_signal_names = ["raw_green", "filtered_green", "raw_405", "filtered_405", "raw_red", "filtered_red", "raw 470/405", "filtered_ratio"]
+    # TODO: Remove filtered signals from comparison for now - check how reference data was processed
+    nwb_signal_names = ["raw_470", "raw_405", "raw_565", "raw_470_405_ratio"]
+    reference_signal_names = ["raw_green",  "raw_405",  "raw_red", "raw 470/405"]
 
     # Compare each signal in the nwbfile to its respective reference
     for sig_name, ref_name in zip(nwb_signal_names, reference_signal_names):

--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -254,8 +254,8 @@ def test_add_photometry_from_pyphotometry():
         ), f"{series_name} has a sampling rate of {getattr(nwbfile.acquisition[series_name], 'rate', None)}, expected {expected_sampling_rate}"
         
     # Check that the photometry series in the nwbfile match the expected signals from the reference dataframe
-    nwb_signal_names = ["raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470_405_ratio", "zscored_470_405_ratio"]
-    reference_signal_names = ["raw_green", "green_z_scored", "raw_405", "z_scored_405", "raw_red", "red_z_scored", "raw 470/405", "ratio_z_scored"]
+    nwb_signal_names = ["raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470_405_ratio"] # add "zscored_470_405_ratio"
+    reference_signal_names = ["raw_green", "green_z_scored", "raw_405", "z_scored_405", "raw_red", "red_z_scored", "raw 470/405"] # add "ratio_z_scored"
 
     # Compare each signal in the nwbfile to its respective reference
     for sig_name, ref_name in zip(nwb_signal_names, reference_signal_names):

--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -233,7 +233,7 @@ def test_add_photometry_from_pyphotometry():
     sampling_rate, visits = add_photometry(nwbfile=nwbfile, metadata=metadata)
 
     # Define the FiberPhotometryResponseSeries we expect to have been added to the nwbfile
-    expected_photometry_series = {"raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470/405", "zscored_470/405"}
+    expected_photometry_series = {"raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470_405_ratio", "zscored_470_405_ratio"}
     expected_sampling_rate = 86 # Hz
     
     # Assert that we have returned the correct sampling rate
@@ -254,7 +254,7 @@ def test_add_photometry_from_pyphotometry():
         ), f"{series_name} has a sampling rate of {getattr(nwbfile.acquisition[series_name], 'rate', None)}, expected {expected_sampling_rate}"
         
     # Check that the photometry series in the nwbfile match the expected signals from the reference dataframe
-    nwb_signal_names = ["raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470/405", "zscored_470/405"]
+    nwb_signal_names = ["raw_470", "z_scored_470", "raw_405", "zscored_405", "raw_565", "zscored_565", "raw_470_405_ratio", "zscored_470_405_ratio"]
     reference_signal_names = ["raw_green", "filtered_green", "raw_405", "filtered_405", "raw_red", "filtered_red", "raw 470/405", "filtered_ratio"]
 
     # Compare each signal in the nwbfile to its respective reference


### PR DESCRIPTION
Reorganize photometry code to separate processing for pyphotometry and labview.
Add tests for pyphotometry processing and update download script to download pyphotometry test data

All pyphotometry signals match their respective reference and all photometry tests pass :)
also, no ruff or codespell errors in photometry conversion and test files