### PR TITLE
Add photometry metadata and tests

### DIFF
--- a/resources/photometry_devices.yaml
+++ b/resources/photometry_devices.yaml
@@ -1,4 +1,4 @@
-# A running list of devices used for photometry. Reference individual devices by keys in the metadata yaml file.
+# A running list of devices used for photometry. Reference individual devices by name in the metadata yaml file.
 
 excitation_sources:
   - name: Purple LED

--- a/resources/photometry_devices.yaml
+++ b/resources/photometry_devices.yaml
@@ -1,0 +1,25 @@
+# A running list of devices used for photometry. Reference individual devices by keys in the metadata yaml file.
+
+excitation_sources:
+  - name: Purple LED
+    excitation_wavelength_in_nm: 470.0
+    manufacturer: ThorLabs
+    model: M405FP1
+    illumination_type: LED
+  - name: Blue LED
+    excitation_wavelength_in_nm: 405.0
+    manufacturer: ThorLabs
+    model: M470F3
+    illumination_type: LED
+
+optic_fibers:
+  - name: Optic Fiber
+    numerical_aperture: 0.39  # TODO get correct value for this
+    core_diameter_in_um: 200.0
+
+photodetectors:
+  - name: Newport Femtowatt Photoreceiver
+    manufacturer: Newport
+    model: "2151"
+    detector_type: Silicon PIN photodiode
+    detected_wavelength_in_nm: 0.0  # TODO modify extension to allow range (320-1050 nm)

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -11,7 +11,7 @@ from scipy.sparse import diags, eye, csc_matrix
 from scipy.sparse.linalg import spsolve
 from sklearn.linear_model import Lasso
 
-from ndx_fiber_photometry import FiberPhotometryResponseSeries
+from ndx_fiber_photometry import FiberPhotometryResponseSeries, ExcitationSource, OpticalFiber, Photodetector
 from .plotting.plot_photometry import (
     plot_raw_photometry_signals,
     plot_405_470_correlation,
@@ -672,9 +672,31 @@ def process_and_add_labview_to_nwb(nwbfile: NWBFile, signals):
 
 
 def add_photometry_metadata(nwbfile: NWBFile, metadata: dict):
-    # TODO for Ryan - add photometry metadata to NWB :)
-    # https://github.com/catalystneuro/ndx-fiber-photometry/tree/main
-    pass
+    """Add photometry metadata to the NWB file.
+    
+    The keys in the metadata YAML are assumed to be the same as the keyword arguments used for the corresponding
+    classes in the ndx-fiber-photometry extension. See the extension for more details:
+    https://github.com/catalystneuro/ndx-fiber-photometry/tree/main
+    """
+    
+    excitation_sources_list = metadata["photometry"]["excitation_sources"]
+    for excitation_source_metadata in excitation_sources_list:
+        excitation_source_obj = ExcitationSource(**excitation_source_metadata)
+        nwbfile.add_device(excitation_source_obj)
+
+    fibers_list = metadata["photometry"]["optic_fibers"]
+    for fiber_metadata in fibers_list:
+        fiber_obj = OpticalFiber(**fiber_metadata)
+        nwbfile.add_device(fiber_obj)
+
+    # TODO: handle optic fiber implant sites
+    # TODO: handle viruses
+    # TODO: handle virus injections
+
+    photodetectors_list = metadata["photometry"]["photodetectors"]
+    for photodetector_metadata in photodetectors_list:
+        photodetector_obj = Photodetector(**photodetector_metadata)
+        nwbfile.add_device(photodetector_obj)
 
 
 def add_photometry(nwbfile: NWBFile, metadata: dict, fig_dir=None):

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -699,56 +699,50 @@ def add_photometry_metadata(nwbfile: NWBFile, metadata: dict):
     # For each type of device, overwrite any metadata from the resources/photometry_devices.yaml file
     # with the metadata from the metadata YAML file
     
-    excitation_sources_list = metadata["photometry"]["excitation_sources"]
-    for new_excitation_source_metadata in excitation_sources_list:
-        excitation_source_name = new_excitation_source_metadata["name"]
+    excitation_source_names = metadata["photometry"]["excitation_sources"]
+    for excitation_source_name in excitation_source_names:
         # Find the matching device by name in the devices list
         for device in devices["excitation_sources"]:
             if device["name"] == excitation_source_name:
-                original_excitation_source_metadata = device
+                excitation_source_metadata = device
                 break
         else:
             raise ValueError(
                 f"Excitation source '{excitation_source_name}' not found in resources/photometry_devices.yaml"
             )
-        combined_excitation_source_metadata = original_excitation_source_metadata | new_excitation_source_metadata
-        excitation_source_obj = ExcitationSource(**combined_excitation_source_metadata)
+        excitation_source_obj = ExcitationSource(**excitation_source_metadata)
         nwbfile.add_device(excitation_source_obj)
 
-    fibers_list = metadata["photometry"]["optic_fibers"]
-    for new_fiber_metadata in fibers_list:
-        fiber_name = new_fiber_metadata["name"]
+    fiber_names = metadata["photometry"]["optic_fibers"]
+    for fiber_name in fiber_names:
         # Find the matching device by name in the devices list
         for device in devices["optic_fibers"]:
             if device["name"] == fiber_name:
-                original_fiber_metadata = device
+                fiber_metadata = device
                 break
         else:
             raise ValueError(
                 f"Optic fiber '{fiber_name}' not found in resources/photometry_devices.yaml"
             )
-        combined_fiber_metadata = original_fiber_metadata | new_fiber_metadata
-        fiber_obj = OpticalFiber(**combined_fiber_metadata)
+        fiber_obj = OpticalFiber(**fiber_metadata)
         nwbfile.add_device(fiber_obj)
 
     # TODO: handle optic fiber implant sites
     # TODO: handle viruses
     # TODO: handle virus injections
 
-    photodetectors_list = metadata["photometry"]["photodetectors"]
-    for new_photodetector_metadata in photodetectors_list:
-        photodetector_name = new_photodetector_metadata["name"]
+    photodetector_names = metadata["photometry"]["photodetectors"]
+    for photodetector_name in photodetector_names:
         # Find the matching device by name in the devices list
         for device in devices["photodetectors"]:
             if device["name"] == photodetector_name:
-                original_photodetector_metadata = device
+                photodetector_metadata = device
                 break
         else:
             raise ValueError(
                 f"Photodetector '{photodetector_name}' not found in resources/photometry_devices.yaml"
             )
-        combined_photodetector_metadata = original_photodetector_metadata | new_photodetector_metadata
-        photodetector_obj = Photodetector(**combined_photodetector_metadata)
+        photodetector_obj = Photodetector(**photodetector_metadata)
         nwbfile.add_device(photodetector_obj)
 
 

--- a/tests/metadata_example.yaml
+++ b/tests/metadata_example.yaml
@@ -60,28 +60,18 @@ photometry:
 
   # see Methods > Photometry section in https://pmc.ncbi.nlm.nih.gov/articles/PMC6555489/#S6 and
   # see Star Methods > Fiber Photometry section in https://pmc.ncbi.nlm.nih.gov/articles/PMC10841332/#S11
-  excitation_sources:
+  excitation_sources:  # reference existing excitation sources from resources/photometry_devices.yaml
     - name: Purple LED
-      excitation_wavelength_in_nm: 470.0
-      manufacturer: ThorLabs
-      model: M405FP1 M00508616
-      illumination_type: LED
     - name: Blue LED
-      excitation_wavelength_in_nm: 405.0
-      manufacturer: ThorLabs
-      model: M470F3 M00511033
-      illumination_type: LED
-  optic_fibers:
-    - name: optic_fiber
-      numerical_aperture: 0.39  # TODO get correct value for this
-      core_diameter_in_um: 200.0
+  optic_fibers:  # reference existing optic fibers from resources/photometry_devices.yaml
+    - name: Optic Fiber
   optic_fiber_implant_sites:
     - reference: bregma at the cortical surface
       hemisphere: right
       ap_in_mm: 1.7
       ml_in_mm: 1.7
       dv_in_mm: -6.0  # 6.0 mm deep for males, 5.8 mm deep for females
-      optic_fiber: optic_fiber  # name of an optic fiber in the 'optic_fibers' field
+      optic_fiber: Optic Fiber  # name of an optic fiber in the 'optic_fibers' field
       excitation_sources:  # names of excitation sources in the 'excitation_sources' field
         - Purple LED  
         - Blue LED
@@ -101,12 +91,8 @@ photometry:
       dv_in_mm: -6.2  # 6.2 mm deep for males, 6.0 mm deep for females
       volume_in_uL: 1.0
       virus: dLight  # name of a virus in the 'viruses' field
-  photodetectors:
+  photodetectors:  # reference existing photodetectors from resources/photometry_devices.yaml
     - name: Newport Femtowatt Photoreceiver
-      manufacturer: Newport
-      model: 2151
-      detector_type: Silicon PIN photodiode
-      detected_wavelength_in_nm: 0.0  # TODO modify extension to allow range (320-1050 nm)
 
 behavior:
   arduino_text_file_path: "tests/test_data/behavior/arduinoraw0.txt"

--- a/tests/metadata_example.yaml
+++ b/tests/metadata_example.yaml
@@ -58,6 +58,55 @@ photometry:
 # signals_mat_file_path: "tests/test_data/downloaded/IM-1478/07252022/signals.mat"
 # ppd_file_path: "tests/test_data/downloaded/IM-1770_corvette/11062024/Lhem_barswitch_GACh4h_rDA3m_CKTL-2024-11-06-185407.ppd"
 
+  # see Methods > Photometry section in https://pmc.ncbi.nlm.nih.gov/articles/PMC6555489/#S6 and
+  # see Star Methods > Fiber Photometry section in https://pmc.ncbi.nlm.nih.gov/articles/PMC10841332/#S11
+  excitation_sources:
+    - name: Purple LED
+      excitation_wavelength_in_nm: 470.0
+      manufacturer: ThorLabs
+      model: M405FP1 M00508616
+      illumination_type: LED
+    - name: Blue LED
+      excitation_wavelength_in_nm: 405.0
+      manufacturer: ThorLabs
+      model: M470F3 M00511033
+      illumination_type: LED
+  optic_fibers:
+    - name: optic_fiber
+      numerical_aperture: 0.39  # TODO get correct value for this
+      core_diameter_in_um: 200.0
+  optic_fiber_implant_sites:
+    - reference: bregma at the cortical surface
+      hemisphere: right
+      ap_in_mm: 1.7
+      ml_in_mm: 1.7
+      dv_in_mm: -6.0  # 6.0 mm deep for males, 5.8 mm deep for females
+      optic_fiber: optic_fiber  # name of an optic fiber in the 'optic_fibers' field
+      excitation_sources:  # names of excitation sources in the 'excitation_sources' field
+        - Purple LED  
+        - Blue LED
+  viruses:
+    - name: dLight
+      construct_name: AAVDJ-CAG-dLight1.3b
+      description: AAV virus with dLight1.3b sensor
+      manufacturer: Vigene
+      titer_in_vg_per_ml: 2e12
+  virus_injections:
+    - description: Injection of dLight AAV virus into right hippocampus CA1
+      location: Hippocampus CA1
+      hemisphere: right
+      reference: bregma at the cortical surface
+      ap_in_mm: 1.7
+      ml_in_mm: 1.7
+      dv_in_mm: -6.2  # 6.2 mm deep for males, 6.0 mm deep for females
+      volume_in_uL: 1.0
+      virus: dLight  # name of a virus in the 'viruses' field
+  photodetectors:
+    - name: Newport Femtowatt Photoreceiver
+      manufacturer: Newport
+      model: 2151
+      detector_type: Silicon PIN photodiode
+      detected_wavelength_in_nm: 0.0  # TODO modify extension to allow range (320-1050 nm)
 
 behavior:
   arduino_text_file_path: "tests/test_data/behavior/arduinoraw0.txt"

--- a/tests/metadata_example.yaml
+++ b/tests/metadata_example.yaml
@@ -61,10 +61,10 @@ photometry:
   # see Methods > Photometry section in https://pmc.ncbi.nlm.nih.gov/articles/PMC6555489/#S6 and
   # see Star Methods > Fiber Photometry section in https://pmc.ncbi.nlm.nih.gov/articles/PMC10841332/#S11
   excitation_sources:  # reference existing excitation sources from resources/photometry_devices.yaml
-    - name: Purple LED
-    - name: Blue LED
+    - Purple LED
+    - Blue LED
   optic_fibers:  # reference existing optic fibers from resources/photometry_devices.yaml
-    - name: Optic Fiber
+    - Optic Fiber
   optic_fiber_implant_sites:
     - reference: bregma at the cortical surface
       hemisphere: right
@@ -92,7 +92,7 @@ photometry:
       volume_in_uL: 1.0
       virus: dLight  # name of a virus in the 'viruses' field
   photodetectors:  # reference existing photodetectors from resources/photometry_devices.yaml
-    - name: Newport Femtowatt Photoreceiver
+    - Newport Femtowatt Photoreceiver
 
 behavior:
   arduino_text_file_path: "tests/test_data/behavior/arduinoraw0.txt"

--- a/tests/metadata_example.yaml
+++ b/tests/metadata_example.yaml
@@ -92,8 +92,8 @@ photometry:
       manufacturer: Vigene
       titer_in_vg_per_ml: 2e12
   virus_injections:
-    - description: Injection of dLight AAV virus into right hippocampus CA1
-      location: Hippocampus CA1
+    - description: Injection of dLight AAV virus into right nucleus accumbens core
+      location: NAcc
       hemisphere: right
       reference: bregma at the cortical surface
       ap_in_mm: 1.7

--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -18,23 +18,17 @@ def add_dummy_photometry_metadata_to_metadata(metadata):
 
     metadata["photometry"]["excitation_sources"] = [
         {
-            "name": "Purple LED",
-            "excitation_wavelength_in_nm": 470.0,
-            "illumination_type": "LED",
+            "name": "Purple LED"
         },
     ]
     metadata["photometry"]["optic_fibers"] = [
         {
-            "name": "optic_fiber",
-            "numerical_aperture": 0.39,
-            "core_diameter_in_um": 200.0,
+            "name": "Optic Fiber"
         },
     ]
     metadata["photometry"]["photodetectors"] = [
         {
-            "name": "photodetector",
-            "detector_type": "Silicon PIN photodiode",
-            "detected_wavelength_in_nm": 0.0,
+            "name": "Newport Femtowatt Photoreceiver"
         },
     ]
     # metadata["photometry"]["optic_fiber_implant_sites"] = []
@@ -353,34 +347,20 @@ def test_add_photometry_metadata():
     metadata["photometry"] = {}
     metadata["photometry"]["excitation_sources"] = [
         {
-            "name": "Purple LED",
-            "excitation_wavelength_in_nm": 470.0,
-            "illumination_type": "LED",
-            "manufacturer": "ThorLabs",
-            "model": "M405FP1 M00508616",
+            "name": "Purple LED"
         },
         {
-            "name": "Blue LED",
-            "excitation_wavelength_in_nm": 405.0,
-            "illumination_type": "LED",
-            "manufacturer": "ThorLabs",
-            "model": "M470F3 M00511033",
+            "name": "Blue LED"
         },
     ]
     metadata["photometry"]["optic_fibers"] = [
         {
-            "name": "optic_fiber",
-            "numerical_aperture": 0.39,
-            "core_diameter_in_um": 200.0,
+            "name": "Optic Fiber"
         },
     ]
     metadata["photometry"]["photodetectors"] = [
         {
-            "name": "Newport Femtowatt Photoreceiver",
-            "manufacturer": "Newport",
-            "model": "2151",
-            "detector_type": "Silicon PIN photodiode",
-            "detected_wavelength_in_nm": 0.0,
+            "name": "Newport Femtowatt Photoreceiver"
         },
     ]
 
@@ -406,15 +386,15 @@ def test_add_photometry_metadata():
     assert nwbfile.devices["Purple LED"].excitation_wavelength_in_nm == 470.0
     assert nwbfile.devices["Purple LED"].illumination_type == "LED"
     assert nwbfile.devices["Purple LED"].manufacturer == "ThorLabs"
-    assert nwbfile.devices["Purple LED"].model == "M405FP1 M00508616"
+    assert nwbfile.devices["Purple LED"].model == "M405FP1"
     assert "Blue LED" in nwbfile.devices
     assert nwbfile.devices["Blue LED"].excitation_wavelength_in_nm == 405.0
     assert nwbfile.devices["Blue LED"].illumination_type == "LED"
     assert nwbfile.devices["Blue LED"].manufacturer == "ThorLabs"
-    assert nwbfile.devices["Blue LED"].model == "M470F3 M00511033"
-    assert "optic_fiber" in nwbfile.devices
-    assert nwbfile.devices["optic_fiber"].numerical_aperture == 0.39
-    assert nwbfile.devices["optic_fiber"].core_diameter_in_um == 200.0
+    assert nwbfile.devices["Blue LED"].model == "M470F3"
+    assert "Optic Fiber" in nwbfile.devices
+    assert nwbfile.devices["Optic Fiber"].numerical_aperture == 0.39
+    assert nwbfile.devices["Optic Fiber"].core_diameter_in_um == 200.0
     assert "Newport Femtowatt Photoreceiver" in nwbfile.devices
     assert nwbfile.devices["Newport Femtowatt Photoreceiver"].manufacturer == "Newport"
     assert nwbfile.devices["Newport Femtowatt Photoreceiver"].model == "2151"

--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -17,19 +17,13 @@ def add_dummy_photometry_metadata_to_metadata(metadata):
     """
 
     metadata["photometry"]["excitation_sources"] = [
-        {
-            "name": "Purple LED"
-        },
+        "Purple LED",
     ]
     metadata["photometry"]["optic_fibers"] = [
-        {
-            "name": "Optic Fiber"
-        },
+        "Optic Fiber",
     ]
     metadata["photometry"]["photodetectors"] = [
-        {
-            "name": "Newport Femtowatt Photoreceiver"
-        },
+        "Newport Femtowatt Photoreceiver",
     ]
     # metadata["photometry"]["optic_fiber_implant_sites"] = []
     # metadata["photometry"]["viruses"] = []
@@ -346,22 +340,14 @@ def test_add_photometry_metadata():
     metadata = {}
     metadata["photometry"] = {}
     metadata["photometry"]["excitation_sources"] = [
-        {
-            "name": "Purple LED"
-        },
-        {
-            "name": "Blue LED"
-        },
+        "Purple LED",
+        "Blue LED",
     ]
     metadata["photometry"]["optic_fibers"] = [
-        {
-            "name": "Optic Fiber"
-        },
+        "Optic Fiber",
     ]
     metadata["photometry"]["photodetectors"] = [
-        {
-            "name": "Newport Femtowatt Photoreceiver"
-        },
+        "Newport Femtowatt Photoreceiver",
     ]
 
     # Create a test NWBFile

--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -10,6 +10,38 @@ from ndx_fiber_photometry import FiberPhotometryResponseSeries
 from jdb_to_nwb.convert_photometry import add_photometry, process_raw_labview_photometry_signals
 
 
+def add_dummy_photometry_metadata_to_metadata(metadata):
+    """
+    Add dummy values to the metadata dictionary so that the tests can run. These values are not tested.
+    test_add_photometry_metadata tests that the values are added correctly.
+    """
+
+    metadata["photometry"]["excitation_sources"] = [
+        {
+            "name": "Purple LED",
+            "excitation_wavelength_in_nm": 470.0,
+            "illumination_type": "LED",
+        },
+    ]
+    metadata["photometry"]["optic_fibers"] = [
+        {
+            "name": "optic_fiber",
+            "numerical_aperture": 0.39,
+            "core_diameter_in_um": 200.0,
+        },
+    ]
+    metadata["photometry"]["photodetectors"] = [
+        {
+            "name": "photodetector",
+            "detector_type": "Silicon PIN photodiode",
+            "detected_wavelength_in_nm": 0.0,
+        },
+    ]
+    # metadata["photometry"]["optic_fiber_implant_sites"] = []
+    # metadata["photometry"]["viruses"] = []
+    # metadata["photometry"]["virus_injections"] = []
+
+
 def test_process_raw_labview_photometry_signals():
     """
     Test that the process_raw_labview_photometry_signals function 
@@ -83,6 +115,7 @@ def test_add_photometry_from_signals_mat():
     metadata = {}
     metadata["photometry"] = {}
     metadata["photometry"]["signals_mat_file_path"] = test_data_dir / "signals.mat"
+    add_dummy_photometry_metadata_to_metadata(metadata)
 
     # Define paths to reference data
     reference_data_path = test_data_dir / "IM-1478_07252022_h_sampleframe.csv"
@@ -158,6 +191,7 @@ def test_add_photometry_from_raw_labview():
     metadata["photometry"] = {}
     metadata["photometry"]["phot_file_path"] = test_data_dir / "IM-1478_2022-07-25_15-24-22____Tim_Conditioning.phot"
     metadata["photometry"]["box_file_path"] = test_data_dir / "IM-1478_2022-07-25_15-24-22____Tim_Conditioning.box"
+    add_dummy_photometry_metadata_to_metadata(metadata)
 
     # Define paths to reference data
     reference_data_path = test_data_dir / "IM-1478_07252022_h_sampleframe.csv"
@@ -239,6 +273,7 @@ def test_add_photometry_from_pyphotometry():
     metadata = {}
     metadata["photometry"] = {}
     metadata["photometry"]["ppd_file_path"] = test_data_dir / "Lhem_barswitch_GACh4h_rDA3m_CKTL-2024-11-06-185407.ppd"
+    add_dummy_photometry_metadata_to_metadata(metadata)
 
     # Define paths to reference data
     reference_data_path = test_data_dir / "sampleframe.csv"
@@ -308,6 +343,85 @@ def test_add_photometry_from_pyphotometry():
         )
 
 
+def test_add_photometry_metadata():
+    """
+    Test that the add_photometry_metadata function adds the expected metadata to the NWB file.
+    """
+
+    # Create a test metadata dictionary
+    metadata = {}
+    metadata["photometry"] = {}
+    metadata["photometry"]["excitation_sources"] = [
+        {
+            "name": "Purple LED",
+            "excitation_wavelength_in_nm": 470.0,
+            "illumination_type": "LED",
+            "manufacturer": "ThorLabs",
+            "model": "M405FP1 M00508616",
+        },
+        {
+            "name": "Blue LED",
+            "excitation_wavelength_in_nm": 405.0,
+            "illumination_type": "LED",
+            "manufacturer": "ThorLabs",
+            "model": "M470F3 M00511033",
+        },
+    ]
+    metadata["photometry"]["optic_fibers"] = [
+        {
+            "name": "optic_fiber",
+            "numerical_aperture": 0.39,
+            "core_diameter_in_um": 200.0,
+        },
+    ]
+    metadata["photometry"]["photodetectors"] = [
+        {
+            "name": "Newport Femtowatt Photoreceiver",
+            "manufacturer": "Newport",
+            "model": "2151",
+            "detector_type": "Silicon PIN photodiode",
+            "detected_wavelength_in_nm": 0.0,
+        },
+    ]
+
+    # Create a test NWBFile
+    nwbfile = NWBFile(
+        session_description="Mock session",
+        session_start_time=datetime.now(tz.tzlocal()),
+        identifier="mock_session",
+    )
+
+    # We do not provide any photometry data to the add_photometry function, so it should raise a ValueError
+    try:
+        add_photometry(nwbfile=nwbfile, metadata=metadata)
+    except ValueError as e:
+        assert str(e).startswith("The required photometry subfields do not exist in the metadata dictionary")
+    else:
+        assert False, (
+            "Expected ValueError was not raised in response to "
+            "missing photometry subfields in the metadata dict."
+        )
+
+    assert "Purple LED" in nwbfile.devices
+    assert nwbfile.devices["Purple LED"].excitation_wavelength_in_nm == 470.0
+    assert nwbfile.devices["Purple LED"].illumination_type == "LED"
+    assert nwbfile.devices["Purple LED"].manufacturer == "ThorLabs"
+    assert nwbfile.devices["Purple LED"].model == "M405FP1 M00508616"
+    assert "Blue LED" in nwbfile.devices
+    assert nwbfile.devices["Blue LED"].excitation_wavelength_in_nm == 405.0
+    assert nwbfile.devices["Blue LED"].illumination_type == "LED"
+    assert nwbfile.devices["Blue LED"].manufacturer == "ThorLabs"
+    assert nwbfile.devices["Blue LED"].model == "M470F3 M00511033"
+    assert "optic_fiber" in nwbfile.devices
+    assert nwbfile.devices["optic_fiber"].numerical_aperture == 0.39
+    assert nwbfile.devices["optic_fiber"].core_diameter_in_um == 200.0
+    assert "Newport Femtowatt Photoreceiver" in nwbfile.devices
+    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].manufacturer == "Newport"
+    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].model == "2151"
+    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].detector_type == "Silicon PIN photodiode"
+    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].detected_wavelength_in_nm == 0.0
+
+
 def test_add_photometry_with_incomplete_metadata(capsys):
     """
     Test that the add_photometry function responds appropriately to missing or incomplete metadata.
@@ -343,8 +457,9 @@ def test_add_photometry_with_incomplete_metadata(capsys):
     assert sampling_rate is None
     assert visits is None
     
-    # Create a test metadata dictionary with a photometry field but no photometry data
+    # Create a test metadata dictionary with a photometry field and metadata but no photometry data
     metadata["photometry"] = {}
+    add_dummy_photometry_metadata_to_metadata(metadata)
     
     # Check that add_photometry raises a ValueError about missing fields in the metadata dictionary
     try:


### PR DESCRIPTION
This is part 1 of adding photometry metadata. This PR handles excitation sources, optic fibers, and photodetectors. There are a few TODOs which we can discuss at our next meeting.

Additionally, we could handle metadata about the optic fiber implant sites, viruses, and virus injection in structured fields that are similar to the ones used by ndx-optogenetics (which is a separate work in progress and is subject to change). Alternatively, this information could be stored in unstructured fields within `surgery` and `virus`. Let me know what you would prefer.