### PR TITLE
Set correct NWB start time, align datastreams to common 0 (photometry start)

### DIFF
--- a/src/jdb_to_nwb/convert.py
+++ b/src/jdb_to_nwb/convert.py
@@ -9,7 +9,7 @@ import shutil
 from pynwb import NWBFile, NWBHDF5IO
 from pynwb.file import Subject
 from datetime import datetime
-from dateutil import tz
+from zoneinfo import ZoneInfo
 
 from . import __version__
 from .convert_video import add_video
@@ -18,6 +18,36 @@ from .convert_raw_ephys import add_raw_ephys
 from .convert_spikes import add_spikes
 from .convert_behavior import add_behavior
 from .convert_photometry import add_photometry
+
+
+def to_datetime(date_str):
+    """
+    Return a datetime object from a date string in MMDDYYYY or YYYYMMDD format.
+    Set the HH:MM:SS time to 00:00:00 Pacific Time.
+    """
+
+    # Convert to string if it's an int, and add a leading 0 if needed
+    # If things get weird here, just specify the date as a string in the first place
+    date_str = str(date_str).zfill(8)
+
+    # Remove slashes and dashes so we can handle formats like MM/DD/YYYY, MM-DD-YYYY, etc
+    date_str = date_str.replace("/", "").replace("-", "")
+
+    if len(date_str) != 8:
+        raise ValueError("Date string must be exactly 8 characters long. "
+                         f"Got date = {date_str} ({len(date_str)} characters)")
+
+    # Auto-detect the date format: if date starts with "20", it must be YYYYMMDD format
+    if date_str.startswith("20"):
+        date_format = "%Y%m%d"
+    # Otherwise, assume MMDDYYYY
+    else:
+        date_format = "%m%d%Y"
+
+    # Convert to datetime and set timezone to Pacific 
+    dt = datetime.strptime(date_str, date_format)
+    dt = dt.replace(tzinfo=ZoneInfo("America/Los_Angeles"))
+    return dt
 
 
 def setup_logger(log_name, path_logfile_info, path_logfile_warn, path_logfile_debug) -> logging.Logger:
@@ -44,12 +74,12 @@ def setup_logger(log_name, path_logfile_info, path_logfile_warn, path_logfile_de
     # Define format for log messages
     formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s", datefmt="%d-%b-%y %H:%M:%S")
 
-    # Handler for logging messages INFO and above to file
+    # Handler for logging messages INFO and above to a file
     fileHandler_info = logging.FileHandler(path_logfile_info, mode="w")
     fileHandler_info.setFormatter(formatter)
     fileHandler_info.setLevel(logging.INFO)
 
-    # Handler for logging messages WARNING and above to file
+    # Handler for logging messages WARNING and above to a file
     fileHandler_warn = logging.FileHandler(path_logfile_warn, mode="w")
     fileHandler_warn.setFormatter(formatter)
     fileHandler_warn.setLevel(logging.WARNING)
@@ -74,6 +104,9 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
 
     # TODO: Add checks for required metadata?
 
+    # Convert date in metadata to datetime object
+    metadata["datetime"] = to_datetime(metadata.get("date"))
+
     # Parse subject metadata
     subject = Subject(**metadata["subject"])
 
@@ -87,7 +120,7 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
     # Create directory for conversion log files
     log_dir = Path(output_nwb_dir) / f"{session_id}_logs"
     os.makedirs(log_dir, exist_ok=True)
-    
+
     # Setup logger with paths to log files
     info_log_file = Path(log_dir) / f"{session_id}_info_logs.log"
     warning_log_file = Path(log_dir) / f"{session_id}_warning_logs.log"
@@ -105,7 +138,7 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
 
     nwbfile = NWBFile(
         session_description="Placeholder description",  # Placeholder: updated in add_behavior
-        session_start_time=datetime.now(tz.tzlocal()),  # Placeholder: updated as the start of the earliest datastream
+        session_start_time=metadata.get("datetime"),    # Placeholder: updated as the start of the earliest datastream
         identifier=str(uuid.uuid4()),
         institution=metadata.get("institution"),
         lab=metadata.get("lab"),
@@ -128,28 +161,33 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
     add_video(nwbfile=nwbfile, metadata=metadata, output_video_path=output_video_path, logger=logger)
     add_dlc(nwbfile=nwbfile, metadata=metadata, logger=logger)
 
-    add_raw_ephys(nwbfile=nwbfile, metadata=metadata, fig_dir=fig_dir)
+    ephys_start = add_raw_ephys(nwbfile=nwbfile, metadata=metadata, fig_dir=fig_dir)
     add_spikes(nwbfile=nwbfile, metadata=metadata)
 
-    # TODO: Time alignment? Or just assign the same time=0 and let NWB do the rest?
-    # If photometry is present, timestamps should be aligned to the photometry
-    # otherwise ephys, otherwise behavior
-    #
-    # For this alignment, add_photometry returns a photometry_data_dict with keys:
+    # If we have an exact photometry start time, use that as the session start time
+    photometry_start = photometry_data_dict.get('photometry_start')
+    if photometry_start is not None:
+        nwbfile.fields["session_start_time"] = photometry_start
+        logger.info(f"Setting session_start_time to photometry start: {photometry_start}")
+    # Otherwise if we have an exact Open Ephys start time, use that
+    elif ephys_start is not None:
+        nwbfile.fields["session_start_time"] = ephys_start
+        logger.info(f"No photometry start time found, so setting session_start_time to ephys start: {ephys_start}")
+    # Otherwise keep the default start time (00:00:00 Pacific Time on the session date)
+    else:
+        logger.warning("No photometry or ephys start time found, \nso session_start_time is the default start time: "
+                       f"{nwbfile.fields["session_start_time"]} (00:00:00 Pacific Time on the session date)")
+
+    # Set the timestamps reference time equal to the session start time
+    nwbfile.fields["timestamps_reference_time"] = nwbfile.fields["session_start_time"]
+
+    # For time alignment, add_photometry returns a photometry_data_dict with keys:
     # - sampling_rate: int (Hz)
     # - port visits: list of port visits in photometry time
     # - photometry_start: datetime object marking the start time of photometry recording
-    # and add_behavior returns: photometry_start_in_arduino_time
-    # For now, ignore that these functions return values because we don't use them yet
-    
+    # add_raw_ephys returns ephys_start (datetime object)
+    # add_behavior returns: photometry_start_in_arduino_time
     # DLC / spatial series currently start at photometry start, so we want to subtract that out!
-    
-    # If we have a recorded photometry start time, use that as the session start time
-    if photometry_data_dict.get('photometry_start') is not None:
-        nwbfile.fields["session_start_time"] = photometry_data_dict.get('photometry_start')
-    else:
-        # Placeholder
-        nwbfile.fields["session_start_time"] = datetime.now(tz.tzlocal())
 
     print("Writing file...")
     output_nwb_file_path = Path(output_nwb_dir) / f"{session_id}.nwb"

--- a/src/jdb_to_nwb/convert.py
+++ b/src/jdb_to_nwb/convert.py
@@ -155,7 +155,7 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
     )
 
     photometry_data_dict = add_photometry(nwbfile=nwbfile, metadata=metadata, fig_dir=fig_dir, logger=logger)
-    add_behavior(nwbfile=nwbfile, metadata=metadata, logger=logger)
+    metadata["photometry_start_in_arduino_ms"] = add_behavior(nwbfile=nwbfile, metadata=metadata, logger=logger)
 
     output_video_path = Path(output_nwb_dir) / f"{session_id}_video.mp4"
     add_video(nwbfile=nwbfile, metadata=metadata, output_video_path=output_video_path, logger=logger)

--- a/src/jdb_to_nwb/convert_raw_ephys.py
+++ b/src/jdb_to_nwb/convert_raw_ephys.py
@@ -3,6 +3,8 @@
 # so we are doing the conversion manually using PyNWB.
 
 import warnings
+from datetime import datetime
+from zoneinfo import ZoneInfo
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from importlib.resources import files
@@ -354,7 +356,7 @@ def add_raw_ephys(
 
     if "ephys" not in metadata:
         print("No ephys metadata found for this session. Skipping ephys conversion.")
-        return
+        return None
 
     # If we do have "ephys" in metadata, check for the required keys
     required_ephys_keys = {"openephys_folder_path", "device", "impedance_file_path"}
@@ -365,10 +367,16 @@ def add_raw_ephys(
             "Remove the 'ephys' field from metadata if you do not have ephys data "
             f"for this session, \nor specify the following missing subfields:{missing_keys}"
         )
-        return
+        return None
 
     print("Adding raw ephys...")
     openephys_folder_path = metadata["ephys"]["openephys_folder_path"]
+
+    # Get Open Ephys start time as datetime object based on the time specified in the path
+    datetime_str = openephys_folder_path.split('/')[-1] # The path ends with the date and time
+    open_ephys_start = datetime.strptime(datetime_str, "%Y-%m-%d_%H-%M-%S")
+    open_ephys_start = open_ephys_start.replace(tzinfo=ZoneInfo("America/Los_Angeles"))
+
     (
         traces_as_iterator,
         channel_conversion_factor_v,
@@ -383,7 +391,7 @@ def add_raw_ephys(
     # Check that the number of electrodes in the NWB file is the same as the number of channels in traces_as_iterator
     assert (len(nwbfile.electrodes) == num_channels), (
         f"Number of electrodes in NWB file ({len(nwbfile.electrodes)}) does not match number of channels "
-        "in traces_as_iterator ({num_channels})."
+        f"in traces_as_iterator ({num_channels})."
     )
 
     # Create the electrode table region encompassing all electrodes
@@ -421,3 +429,5 @@ def add_raw_ephys(
 
     # Add the ElectricalSeries to the NWBFile
     nwbfile.add_acquisition(eseries)
+
+    return open_ephys_start

--- a/src/jdb_to_nwb/convert_raw_ephys.py
+++ b/src/jdb_to_nwb/convert_raw_ephys.py
@@ -252,8 +252,11 @@ def get_raw_ephys_data(
     channel_conversion_offsets = recording_sliced.get_channel_offsets()
     assert all(channel_conversion_offsets == 0), "Channel conversion offsets are not all 0."
 
-    # Get the original timestamps
+    # Get the original timestamps (in seconds)
     original_timestamps = recording_sliced.get_times()
+
+    # TODO when we add logging, log sample frequency
+    # recording.get_sampling_frequency()
 
     # Create a SpikeInterfaceRecordingDataChunkIterator using all default buffering and
     # chunking options. This will be passed to the pynwb.ecephys.ElectricalSeries
@@ -306,7 +309,6 @@ def get_raw_ephys_data(
                 )
             else:
                 filtering[channel.attrib["number"]] = "No filtering"
-                raise ValueError(f"Channel {channel.attrib['number']}: No filtering")
     else:
         raise ValueError("No bandpass filter found in the settings.xml file.")
 

--- a/src/jdb_to_nwb/convert_video.py
+++ b/src/jdb_to_nwb/convert_video.py
@@ -58,6 +58,9 @@ def add_video(nwbfile: NWBFile, metadata: dict, output_video_path, logger):
     with open(video_timestamps_file_path, "r") as video_timestamps_file:
         video_timestamps_ms = np.array(list(csv.reader(video_timestamps_file)), dtype=float).ravel()
 
+    # Adjust video timestamps so photometry starts at time 0
+    video_timestamps_ms = np.subtract(video_timestamps_ms, metadata.get("photometry_start_in_arduino_ms", 0))
+
     # Convert video timestamps to seconds to match NWB standard
     video_timestamps_seconds = video_timestamps_ms / 1000
 

--- a/tests/test_convert_dlc.py
+++ b/tests/test_convert_dlc.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from dateutil import tz
+from zoneinfo import ZoneInfo
 from pynwb import NWBFile
 from pathlib import Path
 
@@ -15,7 +16,7 @@ def test_add_dlc_one_bodypart(dummy_logger):
     test_data_dir = Path("tests/test_data/downloaded/IM-1770_corvette/11062024")
     
     metadata = {}
-    metadata["date"] = "11062024"
+    metadata["datetime"] = datetime.strptime("11062024", "%m%d%Y").replace(tzinfo=ZoneInfo("America/Los_Angeles")) 
     metadata["video"] = {}
     metadata["video"]["video_file_path"] = test_data_dir / "Behav_Vid0.avi"
     metadata["video"]["video_timestamps_file_path"] = test_data_dir / "testvidtimes0.csv"
@@ -74,7 +75,7 @@ def test_add_dlc_two_bodyparts(dummy_logger):
     test_data_dir = Path("tests/test_data/downloaded/IM-1478/07252022")
 
     metadata = {}
-    metadata["date"] = "07252022"
+    metadata["datetime"] = datetime.strptime("07252022", "%m%d%Y").replace(tzinfo=ZoneInfo("America/Los_Angeles")) 
     metadata["video"] = {}
     metadata["video"]["video_file_path"] = test_data_dir / "Behav_Vid0.avi"
     metadata["video"]["video_timestamps_file_path"] = test_data_dir / "testvidtimes0.csv"

--- a/tests/test_convert_raw_ephys.py
+++ b/tests/test_convert_raw_ephys.py
@@ -178,7 +178,7 @@ def test_add_ephys_with_incomplete_metadata(capsys):
 
     # Check that the correct message was printed to stdout
     assert "No ephys metadata found for this session. Skipping ephys conversion." in captured.out
-    assert ephys_start == None
+    assert ephys_start is None
 
     # Create a test metadata dictionary with an ephys field but no ephys data
     metadata["ephys"] = {}
@@ -186,5 +186,5 @@ def test_add_ephys_with_incomplete_metadata(capsys):
     # Check that add_raw_ephys raises a ValueError about missing fields in the metadata dictionary
     ephys_start = add_raw_ephys(nwbfile=nwbfile, metadata=metadata)
     captured = capsys.readouterr()
-    assert ephys_start == None
+    assert ephys_start is None
     assert "The required ephys subfields do not exist in the metadata dictionary" in captured.out


### PR DESCRIPTION
Resolves #81 
- Sets NWB start time and reference time to the photometry start time. If we don't have that then ephys start time. If we don't have that then noon Pacific time on the recording day

Resolves #82 
- Converts all timestamps to seconds (or indicates correct sample rate such that NWB naturally converts). Behavior and video/DLC (aka arduino-based timestamps) now start from time 0, where 0 is the photometry start. This has not yet been done for ephys and will be addressed in a follow up PR that interpolates timestamps based on port visits

Also resolves #70 (one line fix because we don't actually want the pipeline to complain about no filtering)