### PR TITLE
Add epochs and tasks processing module for spyglass compatability

### DIFF
--- a/src/jdb_to_nwb/convert_behavior.py
+++ b/src/jdb_to_nwb/convert_behavior.py
@@ -553,7 +553,7 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger):
     epoch_tag = "00_r1" # This is epoch 0 and run session 1
     nwbfile.add_epoch(start_time=session_start, stop_time=session_end, tags=epoch_tag)
 
-    # Add tasks processing module for compatability with Spyglass
+    # Add tasks processing module for compatibility with Spyglass
     # Many of these fields are repetitive but exist to match Frank Lab
     nwbfile.create_processing_module(
         name="tasks", description="Contains all tasks information"
@@ -585,7 +585,7 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger):
     #     data=[[int(camera_id) for camera_id in task_metadata["camera_id"]]],
     # )
     task = DynamicTable(
-        name=f"task_0",
+        name="task_0",
         description="",
         columns=[
             task_name,

--- a/src/jdb_to_nwb/convert_behavior.py
+++ b/src/jdb_to_nwb/convert_behavior.py
@@ -511,11 +511,17 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger):
         f"{session_type} session for the hex maze task with {len(block_data)} blocks and {len(trial_data)} trials."
     )
 
+    # Add a single epoch to the NWB for this session
+    session_start = block_data[0]["start_time"]
+    session_end = block_data[-1]["end_time"]
+    epoch_tag = "00_r1" # This is epoch 0 and run session 1
+    nwbfile.add_epoch(start_time=session_start, stop_time=session_end, tags=epoch_tag)
+
     # Add each block to the block table in the NWB
     logger.debug("Adding each block to the block table in the NWB")
     for block in block_data:
         block_table.add_row(
-            epoch=1, # Berke Lab only has one epoch (session) per day
+            epoch=0, # Berke Lab only has one epoch (session) per day
             block=block["block"],
             maze_configuration=block["maze_configuration"],
             pA=block["pA"],
@@ -526,12 +532,12 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger):
             start_time=block["start_time"],
             stop_time=block["end_time"],
         )
- 
+
     # Add each trial to the NWB
     logger.debug("Adding each trial to the trial table in the NWB")
     for trial in trial_data:
         nwbfile.add_trial(
-            epoch=1, # Berke Lab only has one epoch (session) per day
+            epoch=0, # Berke Lab only has one epoch (session) per day
             block=trial["block"],
             trial_within_block=trial["trial_within_block"],
             trial_within_epoch=trial["trial_within_session"],
@@ -557,13 +563,13 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger):
         name="arduino_text",
         description="Raw arduino text",
         content=raw_arduino_text,
-        task_epochs="1",  # Berke Lab only has one epoch (session) per day
+        task_epochs="0",  # Berke Lab only has one epoch (session) per day
     )
     raw_arduino_timestamps_file = AssociatedFiles(
         name="arduino_timestamps",
         description="Raw arduino timestamps",
         content=raw_arduino_timestamps,
-        task_epochs="1",  # Berke Lab only has one epoch (session) per day
+        task_epochs="0",  # Berke Lab only has one epoch (session) per day
     )
 
     # Add arduino text and timestamps to the NWB as associated files

--- a/tests/test_convert_behavior.py
+++ b/tests/test_convert_behavior.py
@@ -54,7 +54,9 @@ def test_convert_behavior(dummy_logger):
     for val in task.columns:
         assert isinstance(val, VectorData)
     expected_task_columns = {"task_name", "task_description", "task_epochs", "task_environment"}
-    assert set(task.colnames) == expected_task_columns, f"Task columns {set(task.colnames)} did not match expected {expected_task_columns}"
+    assert set(task.colnames) == expected_task_columns, (
+        f"Task columns {set(task.colnames)} did not match expected {expected_task_columns}"
+    )
 
     # Test that the nwbfile has the expected associated files
     assert "associated_files" in nwbfile.processing

--- a/tests/test_convert_behavior.py
+++ b/tests/test_convert_behavior.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from dateutil import tz
 from pynwb import NWBFile
+from pynwb.file import ProcessingModule
+from hdmf.common.table import DynamicTable, VectorData
 
 from jdb_to_nwb.convert_behavior import add_behavior
 
@@ -33,6 +35,26 @@ def test_convert_behavior(dummy_logger):
     # enumerated correctly, block metadata is valid, number of trials per block adds to the
     # total number of trials, block start/end times are aligned to trial start/end times)
     # because these checks are already run by validate_trial_and_block_data every time add_behavior is run
+    
+    # Test that the tasks processing module has been added
+    assert "tasks" in nwbfile.processing
+    tasks_module = nwbfile.processing["tasks"]
+    assert isinstance(tasks_module, ProcessingModule)
+    assert tasks_module.name == "tasks"
+    assert tasks_module.description == "Contains all tasks information"
+
+    # We should have a single task named task_0
+    assert len(tasks_module.data_interfaces) == 1
+    task = tasks_module.data_interfaces["task_0"]
+    assert isinstance(task, DynamicTable)
+    assert task.name == "task_0"
+    assert task.description == ""
+
+    # Check if the task metadata columns were added correctly
+    for val in task.columns:
+        assert isinstance(val, VectorData)
+    expected_task_columns = {"task_name", "task_description", "task_epochs", "task_environment"}
+    assert set(task.colnames) == expected_task_columns, f"Task columns {set(task.colnames)} did not match expected {expected_task_columns}"
 
     # Test that the nwbfile has the expected associated files
     assert "associated_files" in nwbfile.processing


### PR DESCRIPTION
Resolves #88 

Berke Lab only has a single session per day, so the epoch is the entire session. Everything is epoch 0. The epoch tag is "00_r1" (for epoch 0 and run session 1) to match how Xulu's epochs are tagged, but it doesn't really matter.

Also updates tests to check for the tasks processing module. All tests pass :)