### PR TITLE
Replace np.matrix

### DIFF
--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -317,7 +317,8 @@ def whittaker_smooth(data, binary_mask, lambda_):
     the fitted background vector
     """
 
-    data_matrix = np.matrix(data)
+    data_matrix = np.array(data)
+    data_matrix = np.expand_dims(data_matrix, axis=0)  # Convert to 2D array (1, num_samples)
     data_size = data_matrix.size  # Size of the data matrix
     # Create an identity matrix the size of the data matrix in compressed sparse column (csc) format
     identity_matrix = eye(data_size, format="csc")


### PR DESCRIPTION
Converting the photometry data was resulting in the warning:
```
  /Users/rly/Documents/NWB/temp/jdb_to_nwb/src/jdb_to_nwb/convert_photometry.py:323: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
    np.matrix(data)
```
A possible recent change to numpy or scipy made this result in errors downstream. "ValueError: ndarray is not contiguous"

This PR replaces np.matrix with np.array and added a dummy first dimension to the array to maintain the previous behavior.