### PR TITLE
Spyglass compatibility: add CameraDevice for TaskEpoch table, change date format

### DIFF
--- a/src/jdb_to_nwb/convert.py
+++ b/src/jdb_to_nwb/convert.py
@@ -110,8 +110,8 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
     # Parse subject metadata
     subject = Subject(**metadata["subject"])
 
-    # Create session_id in rat_date format
-    session_id = f"{metadata.get("animal_name")}_{metadata.get("date")}"
+    # Create session_id in {rat}_{date} format where date is YYYYMMDD
+    session_id = f"{metadata.get("animal_name")}_{metadata.get("datetime").strftime("%Y%m%d")}"
 
     # Create directory for associated figures
     fig_dir = Path(output_nwb_dir) / f"{session_id}_figures"

--- a/src/jdb_to_nwb/convert_behavior.py
+++ b/src/jdb_to_nwb/convert_behavior.py
@@ -571,19 +571,18 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger):
     task_epochs = VectorData(
         name="task_epochs",
         description="the temporal epochs where the animal was exposed to this task",
-        data=[0],
+        data=[[0]],
     )
     task_environment = VectorData(
         name="task_environment",
         description="the environment in which the animal performed the task",
         data=["hexmaze"],
     )
-    # Keeping for posterity if we add camera data like Frank Lab
-    # camera_id = VectorData(
-    #     name="camera_id",
-    #     description="the ID number of the camera used for video",
-    #     data=[[int(camera_id) for camera_id in task_metadata["camera_id"]]],
-    # )
+    camera_id = VectorData(
+        name="camera_id",
+        description="the ID number of the camera used for video",
+        data=[[1]],
+    )
     task = DynamicTable(
         name="task_0",
         description="",
@@ -592,7 +591,7 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger):
             task_description,
             task_epochs,
             task_environment,
-            # camera_id,
+            camera_id,
         ],
     )
     nwbfile.processing["tasks"].add(task)

--- a/src/jdb_to_nwb/convert_position.py
+++ b/src/jdb_to_nwb/convert_position.py
@@ -1,39 +1,9 @@
 import csv
 import numpy as np
 import pandas as pd
-from datetime import datetime
-from zoneinfo import ZoneInfo
 from pynwb import NWBFile, TimeSeries
 from pynwb.behavior import Position
 from scipy.interpolate import interp1d
-from hdmf.common import DynamicTable
-
-
-def assign_pixels_per_cm(session_date):
-    """
-    Assigns default PIXELS_PER_CM based on the date of the session.
-    PIXELS_PER_CM is 3.14 if video is before IM-1594 (before 01/01/2023), 
-    2.3 before (01/11/2024), or 2.688 after (old maze)
-
-    Args:
-    session_date (datetime): Datetime object for the date of this session
-
-    Returns:
-    float: The corresponding PIXELS_PER_CM value.
-    """
-
-    # Define cutoff dates
-    cutoff1 = datetime.strptime("12312022", "%m%d%Y").replace(tzinfo=ZoneInfo("America/Los_Angeles"))  # Dec 31, 2022
-    cutoff2 = datetime.strptime("01112024", "%m%d%Y").replace(tzinfo=ZoneInfo("America/Los_Angeles"))  # Jan 11, 2024
-
-    # Assign pixels per cm based on the session date
-    if session_date <= cutoff1:
-        pixels_per_cm = 3.14
-    elif cutoff1 < session_date <= cutoff2:
-        pixels_per_cm = 2.3
-    else:
-        pixels_per_cm = 2.688 # After January 11, 2024
-    return pixels_per_cm
 
 
 def read_dlc(deeplabcut_file_path, pixels_per_cm, logger, likelihood_cutoff=0.9, cam_fps=15):
@@ -187,7 +157,7 @@ def add_position_to_nwb(nwbfile: NWBFile, position_data: list[tuple], pixels_per
     pixels_per_cm: pixels per cm conversion rate of the position data
     video_timestamps: timestamps of each camera frame (aka position datapoint) in seconds
     """
-    
+
     # Convert pixels_per_cm to meters_per_pixel for consistency with Frank Lab
     meters_per_pixel = 0.01 / pixels_per_cm
     logger.debug(f"Meters per pixel: {meters_per_pixel}")
@@ -200,7 +170,7 @@ def add_position_to_nwb(nwbfile: NWBFile, position_data: list[tuple], pixels_per
         )
 
     position = Position(name="position")
-    
+
     # Add x,y position to the nwb as a SpatialSeries for each tracked body part
     for body_part_name, body_part_position_df in position_data:
         logger.info(f"Adding position data for {body_part_name} to the nwb...")
@@ -239,103 +209,20 @@ def add_position_to_nwb(nwbfile: NWBFile, position_data: list[tuple], pixels_per
     nwbfile.processing["behavior"].add(position)
 
 
-def add_hex_centroids(nwbfile: NWBFile, metadata: dict, pixels_per_cm, logger):
-    """
-    Read hex centroids from a csv file with columns hex, x, y 
-    and add them to the nwbfile in the behavior processing module.
-    """
-
-    hex_centroids_file = metadata["video"].get("hex_centroids_file_path")
-    if hex_centroids_file is None:
-        print("No subfield 'hex_centroids_file_path' found in video metadata! Skipping adding hex centroids.")
-        logger.warning("No subfield 'hex_centroids_file_path' found in video metadata! Skipping adding hex centroids.")
-        return
-
-    try:
-        hex_centroids = pd.read_csv(hex_centroids_file)
-    except FileNotFoundError:
-        logger.error(f"The file '{hex_centroids_file}' was not found! Skipping adding hex centroids.")
-        print(f"Error: The file '{hex_centroids_file}' was not found! Skipping adding hex centroids.")
-        return
-
-    # Check that the hex centroids file is in the format we expect
-    num_hexes = 49
-    if len(hex_centroids) != num_hexes:
-        logger.error(f"Expected {num_hexes} centroids in the hex centroids file, got {len(hex_centroids)}!!!")
-    else:
-        logger.debug(f"Found the expected number of hex centroids in the centroids file ({num_hexes})")
-
-    expected_columns = {'hex', 'x', 'y'}
-    if set(hex_centroids.columns) != expected_columns:
-        logger.error(f"Expected {expected_columns} columns in the hex centroids file, "
-                     f"got {set(hex_centroids.columns)}!!")
-        logger.error("Skipping adding centroids to the nwb")
-        print(f"Expected {expected_columns} columns in the hex centroids file, got {set(hex_centroids.columns)}!")
-        print("Skipping adding centroids to the nwb.")
-        return
-    else:
-        logger.debug(f"Found expected columns {expected_columns} in the hex centroids file")
-
-    # Convert pixels per cm to meters per pixel
-    meters_per_pixel = 0.01 / pixels_per_cm
-    hex_centroids['x_meters'] = hex_centroids['x'] * meters_per_pixel
-    hex_centroids['y_meters'] = hex_centroids['y'] * meters_per_pixel
-
-    # Set up the hex centroids table
-    centroids_table = DynamicTable(name="hex_centroids", 
-            description="Centroids of each hex in the maze (in video pixel coordinates)")
-    centroids_table.add_column(name="hex", description="The ID of the hex in the maze (1-49)")
-    centroids_table.add_column(name="x",
-            description="The x coordinate of the center of the hex (in video pixel coordinates)")
-    centroids_table.add_column(name="y",
-            description="The y coordinate of the center of the hex (in video pixel coordinates)")
-    centroids_table.add_column(name="x_meters", 
-            description="The x coordinate of the center of the hex (in meters)")
-    centroids_table.add_column(name="y_meters", 
-            description="The y coordinate of the center of the hex (in meters)")
-    # Add the hex centroids
-    for _, row in hex_centroids.iterrows():
-        centroids_table.add_row(**row.to_dict())
-
-    # If it doesn't exist already, make a processing module for behavior and add to the nwbfile
-    if "behavior" not in nwbfile.processing:
-        logger.debug("Creating nwb behavior processing module for position data")
-        nwbfile.create_processing_module(
-            name="behavior", description="Contains all behavior-related data"
-        )
-
-    print("Adding hex centroids to the nwb...")
-    logger.info("Adding hex centroids to the behavior processing module in the nwbfile")
-    nwbfile.processing["behavior"].add(centroids_table)
-
-
 def add_position(nwbfile: NWBFile, metadata: dict, logger):
+    """ 
+    Add positon data from DeeplabCut to the nwbfile.
+    """
 
     if "video" not in metadata:
         # Do not print "no video metadata found" message, because we already print that in add_video
         return
 
-    # If pixels_per_cm exists in metadata, use that value
-    if "pixels_per_cm" in metadata["video"]:
-        PIXELS_PER_CM = metadata["video"]["pixels_per_cm"]
-        logger.info(f"Assigning video PIXELS_PER_CM={PIXELS_PER_CM} from metadata.")
-    # Otherwise, assign it based on the date of the experiment
-    else:
-        PIXELS_PER_CM = assign_pixels_per_cm(metadata["datetime"])
-        logger.info("No 'pixels_per_cm' value found in video metadata.")
-        logger.info(f"Automatically assigned video PIXELS_PER_CM={PIXELS_PER_CM} based on date of experiment.")
-
-    if "hex_centroids_file_path" in metadata["video"]:
-        add_hex_centroids(nwbfile=nwbfile, metadata=metadata, pixels_per_cm=PIXELS_PER_CM, logger=logger)
-    else:
-        print("No subfield 'hex_centroids_file_path' found in video metadata! Skipping adding hex centroids.")
-        logger.warning("No subfield 'hex_centroids_file_path' found in video metadata! Skipping adding hex centroids.")
-
     # It is ok if we have video field in metadata but not DLC data
     # The user may wish to only convert the raw video file and do position tracking later
     if "dlc_path" not in metadata["video"]:
         print("No DeepLabCut (DLC) metadata found for this session. Skipping DLC conversion.")
-        logger.info("No DeepLabCut (DLC) metadata found for this session. Skipping DLC conversion.")
+        logger.warning("No DeepLabCut (DLC) metadata found for this session. Skipping DLC conversion.")
         return
 
     # If we do have dlc_path, we must also have video timestamps for DLC conversion
@@ -349,46 +236,50 @@ def add_position(nwbfile: NWBFile, metadata: dict, logger):
             "If you do not wish to convert DeepLabCut data, please remove field 'dlc_path' from metadata."
             )
         return
+
+    # At this point, pixels_per_cm exists must under video in metadata. If it did not exist, 
+    # it was automatically assigned based on session date in convert_video
+    pixels_per_cm = metadata["video"]["pixels_per_cm"]
+
+    # Read timestamps of each camera frame (in ms)
+    video_timestamps_file_path = metadata["video"]["video_timestamps_file_path"]
+    with open(video_timestamps_file_path, "r") as video_timestamps_file:
+        video_timestamps_ms = np.array(list(csv.reader(video_timestamps_file)), dtype=float).ravel()
+
+    # Adjust video timestamps so photometry starts at time 0 and convert to seconds to match NWB standard
+    video_timestamps_ms = np.subtract(video_timestamps_ms, metadata.get("photometry_start_in_arduino_ms", 0))
+    video_timestamps_seconds = video_timestamps_ms / 1000
+
+    # Align video timestamps to photometry/ephys
+    ground_truth_visit_times = metadata.get("photometry_visit_times", metadata.get("ephys_visit_times"))
+    arduino_visit_times = metadata.get("arduino_visit_times")
+
+    if ground_truth_visit_times is not None:
+        logger.info("Aligning DLC timestamps...")
+        # Make sure we have the same number of arduino and ground truth visit times for alignment
+        assert len(arduino_visit_times) == len(ground_truth_visit_times), (
+            f"Expected the same number of port visits recorded by arduino and ephys/photometry! \n"
+            f"Got {len(arduino_visit_times)} arduino visits, "
+            f"but {len(ground_truth_visit_times)} visits for alignment!"
+        )
+        # Align video timestamps via interpolation. For timestamps out of visit bounds, 
+        # use the ratio of spacing between arduino_visit_times and ground_truth_visit_times
+        true_video_timestamps = np.interp(
+            x=video_timestamps_seconds,
+            xp=arduino_visit_times,
+            fp=ground_truth_visit_times,
+            left=ground_truth_visit_times[0] + 
+                (video_timestamps_seconds[0] - arduino_visit_times[0]) * 
+                (ground_truth_visit_times[1] - ground_truth_visit_times[0]) / 
+                (arduino_visit_times[1] - arduino_visit_times[0]),
+            right=ground_truth_visit_times[-1] + 
+                (video_timestamps_seconds[-1] - arduino_visit_times[-1]) * 
+                (ground_truth_visit_times[-1] - ground_truth_visit_times[-2]) / 
+                (arduino_visit_times[-1] - arduino_visit_times[-2])
+        )
     else:
-        # Read timestamps of each camera frame (in ms)
-        video_timestamps_file_path = metadata["video"]["video_timestamps_file_path"]
-        with open(video_timestamps_file_path, "r") as video_timestamps_file:
-            video_timestamps_ms = np.array(list(csv.reader(video_timestamps_file)), dtype=float).ravel()
- 
-        # Adjust video timestamps so photometry starts at time 0 and convert to seconds to match NWB standard
-        video_timestamps_ms = np.subtract(video_timestamps_ms, metadata.get("photometry_start_in_arduino_ms", 0))
-        video_timestamps_seconds = video_timestamps_ms / 1000
-
-        # Align video timestamps to photometry/ephys
-        ground_truth_visit_times = metadata.get("photometry_visit_times", metadata.get("ephys_visit_times"))
-        arduino_visit_times = metadata.get("arduino_visit_times")
-
-        if ground_truth_visit_times is not None:
-            logger.info("Aligning DLC timestamps...")
-            # Make sure we have the same number of arduino and ground truth visit times for alignment
-            assert len(arduino_visit_times) == len(ground_truth_visit_times), (
-                f"Expected the same number of port visits recorded by arduino and ephys/photometry! \n"
-                f"Got {len(arduino_visit_times)} arduino visits, "
-                f"but {len(ground_truth_visit_times)} visits for alignment!"
-            )
-            # Align video timestamps via interpolation. For timestamps out of visit bounds, 
-            # use the ratio of spacing between arduino_visit_times and ground_truth_visit_times
-            true_video_timestamps = np.interp(
-                x=video_timestamps_seconds,
-                xp=arduino_visit_times,
-                fp=ground_truth_visit_times,
-                left=ground_truth_visit_times[0] + 
-                    (video_timestamps_seconds[0] - arduino_visit_times[0]) * 
-                    (ground_truth_visit_times[1] - ground_truth_visit_times[0]) / 
-                    (arduino_visit_times[1] - arduino_visit_times[0]),
-                right=ground_truth_visit_times[-1] + 
-                    (video_timestamps_seconds[-1] - arduino_visit_times[-1]) * 
-                    (ground_truth_visit_times[-1] - ground_truth_visit_times[-2]) / 
-                    (arduino_visit_times[-1] - arduino_visit_times[-2])
-            )
-        else:
-            # If we don't have port visits for alignment, keep the original timestamps
-            true_video_timestamps = video_timestamps_seconds
+        # If we don't have port visits for alignment, keep the original timestamps
+        true_video_timestamps = video_timestamps_seconds
 
     print("Adding position data from DeepLabCut...")
     logger.info("Adding position data from DeepLabCut...")
@@ -398,9 +289,9 @@ def add_position(nwbfile: NWBFile, metadata: dict, logger):
     deeplabcut_file_path = metadata["video"]["dlc_path"]
 
     # Read x, y position data and calculate velocity and acceleration
-    position_dfs = read_dlc(deeplabcut_file_path, pixels_per_cm=PIXELS_PER_CM, logger=logger, 
+    position_dfs = read_dlc(deeplabcut_file_path, pixels_per_cm=pixels_per_cm, logger=logger, 
                             likelihood_cutoff=0.9, cam_fps=15)
 
     # Add x, y position data to the nwbfile
     add_position_to_nwb(nwbfile, position_data=position_dfs, 
-                        pixels_per_cm=PIXELS_PER_CM, video_timestamps=true_video_timestamps, logger=logger)
+                        pixels_per_cm=pixels_per_cm, video_timestamps=true_video_timestamps, logger=logger)

--- a/src/jdb_to_nwb/convert_position.py
+++ b/src/jdb_to_nwb/convert_position.py
@@ -211,7 +211,7 @@ def add_position_to_nwb(nwbfile: NWBFile, position_data: list[tuple], pixels_per
 
 def add_position(nwbfile: NWBFile, metadata: dict, logger):
     """ 
-    Add positon data from DeeplabCut to the nwbfile.
+    Add position data from DeeplabCut to the nwbfile.
     """
 
     if "video" not in metadata:

--- a/src/jdb_to_nwb/convert_position.py
+++ b/src/jdb_to_nwb/convert_position.py
@@ -237,9 +237,9 @@ def add_position(nwbfile: NWBFile, metadata: dict, logger):
             )
         return
 
-    # At this point, pixels_per_cm exists must under video in metadata. If it did not exist, 
+    # At this point, pixels_per_cm must exist in metadata. If it did not exist, 
     # it was automatically assigned based on session date in convert_video
-    pixels_per_cm = metadata["video"]["pixels_per_cm"]
+    pixels_per_cm = metadata["pixels_per_cm"]
 
     # Read timestamps of each camera frame (in ms)
     video_timestamps_file_path = metadata["video"]["video_timestamps_file_path"]

--- a/src/jdb_to_nwb/convert_video.py
+++ b/src/jdb_to_nwb/convert_video.py
@@ -46,24 +46,12 @@ def add_camera(nwbfile: NWBFile):
         CameraDevice(
             name="camera_device 1",
             meters_per_pixel=meters_per_pixel,
-            manufacturer="Camera manufacturer",
-            model="Camera model",
-            lens="Camera lens",
-            camera_name="Hex maze camera",
+            manufacturer="Logitech",
+            model="Brio webcam",
+            lens="lens",
+            camera_name="maze_camera",
         )
     )
-
-    # From Frank lab:
-    # nwbfile.add_device(
-    #         CameraDevice(
-    #             name="camera_device " + str(camera_metadata["id"]),
-    #             meters_per_pixel=camera_metadata["meters_per_pixel"],
-    #             manufacturer=camera_metadata["manufacturer"],
-    #             model=camera_metadata["model"],
-    #             lens=camera_metadata["lens"],
-    #             camera_name=camera_metadata["camera_name"],
-    #         )
-    #     )
 
 
 def add_video(nwbfile: NWBFile, metadata: dict, output_video_path, logger):

--- a/src/jdb_to_nwb/convert_video.py
+++ b/src/jdb_to_nwb/convert_video.py
@@ -146,7 +146,7 @@ def add_camera(nwbfile: NWBFile, metadata: dict):
     pixels_per_cm = metadata["video"]["pixels_per_cm"]
     meters_per_pixel = 0.01 / pixels_per_cm
 
-    # Note that the name "camera_device 1" is required for spyglass compatability 
+    # Note that the name "camera_device 1" is required for spyglass compatibility
     # (it must match format "camera_device {epoch+1}")
     nwbfile.add_device(
         CameraDevice(

--- a/src/jdb_to_nwb/convert_video.py
+++ b/src/jdb_to_nwb/convert_video.py
@@ -5,6 +5,7 @@ import numpy as np
 from pynwb import NWBFile
 from pynwb.image import ImageSeries
 from pynwb.behavior import BehavioralEvents
+from ndx_franklab_novela import CameraDevice
 
 
 def compress_avi_to_mp4(input_video_path, output_video_path, logger, crf=23, preset="ultrafast"):
@@ -32,6 +33,39 @@ def compress_avi_to_mp4(input_video_path, output_video_path, logger, crf=23, pre
         print(str(e))
 
 
+def add_camera(nwbfile: NWBFile):
+    '''
+    Adds camera because this is required to create a TaskEpoch in spyglass.
+    Data is currently placeholder values.
+    '''
+    
+    pixels_per_cm = 3.14
+    meters_per_pixel = 0.01 / pixels_per_cm
+    
+    nwbfile.add_device(
+        CameraDevice(
+            name="camera_device 1",
+            meters_per_pixel=meters_per_pixel,
+            manufacturer="Camera manufacturer",
+            model="Camera model",
+            lens="Camera lens",
+            camera_name="Hex maze camera",
+        )
+    )
+
+    # From Frank lab:
+    # nwbfile.add_device(
+    #         CameraDevice(
+    #             name="camera_device " + str(camera_metadata["id"]),
+    #             meters_per_pixel=camera_metadata["meters_per_pixel"],
+    #             manufacturer=camera_metadata["manufacturer"],
+    #             model=camera_metadata["model"],
+    #             lens=camera_metadata["lens"],
+    #             camera_name=camera_metadata["camera_name"],
+    #         )
+    #     )
+
+
 def add_video(nwbfile: NWBFile, metadata: dict, output_video_path, logger):
 
     if "video" not in metadata:
@@ -49,6 +83,10 @@ def add_video(nwbfile: NWBFile, metadata: dict, output_video_path, logger):
 
     print("Adding video...")
     logger.info("Adding video...")
+    
+    print("Adding camera...")
+    logger.info("Adding camera...")
+    add_camera(nwbfile)
 
     # Get file paths for video from metadata file
     video_file_path = metadata["video"]["video_file_path"]

--- a/tests/test_convert_behavior.py
+++ b/tests/test_convert_behavior.py
@@ -53,7 +53,7 @@ def test_convert_behavior(dummy_logger):
     # Check if the task metadata columns were added correctly
     for val in task.columns:
         assert isinstance(val, VectorData)
-    expected_task_columns = {"task_name", "task_description", "task_epochs", "task_environment"}
+    expected_task_columns = {"task_name", "task_description", "task_epochs", "task_environment", "camera_id"}
     assert set(task.colnames) == expected_task_columns, (
         f"Task columns {set(task.colnames)} did not match expected {expected_task_columns}"
     )

--- a/tests/test_convert_position.py
+++ b/tests/test_convert_position.py
@@ -1,11 +1,9 @@
 from datetime import datetime
 from dateutil import tz
-from zoneinfo import ZoneInfo
 from pynwb import NWBFile
 from pathlib import Path
-from hdmf.common.table import DynamicTable, VectorData
 
-from jdb_to_nwb.convert_position import add_position, add_hex_centroids
+from jdb_to_nwb.convert_position import add_position
 
 
 def test_add_dlc_one_bodypart(dummy_logger):
@@ -15,11 +13,10 @@ def test_add_dlc_one_bodypart(dummy_logger):
     """
 
     test_data_dir = Path("tests/test_data/downloaded/IM-1770_corvette/11062024")
-    
+
     metadata = {}
-    metadata["datetime"] = datetime.strptime("11062024", "%m%d%Y").replace(tzinfo=ZoneInfo("America/Los_Angeles")) 
     metadata["video"] = {}
-    metadata["video"]["video_file_path"] = test_data_dir / "Behav_Vid0.avi"
+    metadata["video"]["pixels_per_cm"] = 2.688
     metadata["video"]["video_timestamps_file_path"] = test_data_dir / "testvidtimes0.csv"
     metadata["video"]["dlc_path"] = test_data_dir / "Behav_Vid0DLC_resnet50_Triangle_Maze_PhotFeb12shuffle1_800000.h5"
 
@@ -67,53 +64,6 @@ def test_add_dlc_one_bodypart(dummy_logger):
         assert dlc_likelihood.comments.startswith(expected_comment)
 
 
-def test_add_hex_centroids(dummy_logger):
-    """
-    Test the add_hex_centroids function
-    """
-    
-    test_data_dir = Path("tests/test_data/downloaded/IM-1478/07252022")
-
-    metadata = {}
-    metadata["datetime"] = datetime.strptime("07252022", "%m%d%Y").replace(tzinfo=ZoneInfo("America/Los_Angeles")) 
-    metadata["video"] = {}
-    metadata["video"]["hex_centroids_file_path"] = test_data_dir / "hex_coordinates_IM-1478_07252022.csv"
-    pixels_per_cm = 3.14
-    
-    nwbfile = NWBFile(
-        session_description="Mock session",
-        session_start_time=datetime.now(tz.tzlocal()),
-        identifier="mock_session",
-    )
-
-    # Add centroids table to the nwb
-    add_hex_centroids(nwbfile=nwbfile, metadata=metadata, pixels_per_cm=pixels_per_cm, logger=dummy_logger)
-
-    # Check that behavior processing module has been added
-    assert "behavior" in nwbfile.processing
-
-    # Check that the "hex_centroids" table exists in the behavior processing module
-    behavior_module = nwbfile.processing["behavior"]
-    assert "hex_centroids" in behavior_module.data_interfaces
-    hex_centroids_table = behavior_module.data_interfaces["hex_centroids"]
-
-    assert isinstance(hex_centroids_table, DynamicTable)
-    assert hex_centroids_table.name == "hex_centroids"
-    assert hex_centroids_table.description == "Centroids of each hex in the maze (in video pixel coordinates)"
-
-    # The table should have data for all 49 hex centroids
-    assert len(hex_centroids_table) == 49
-
-    # Check that the table contains the correct columns
-    for column in hex_centroids_table.columns:
-        assert isinstance(column, VectorData)
-    expected_columns = {"hex", "x", "y", "x_meters", "y_meters"}
-    assert set(hex_centroids_table.colnames) == expected_columns, (
-        f"Hex centroid columns {set(hex_centroids_table.colnames)} "
-        f"did not match expected {expected_columns}"
-    )
-
-
 def test_add_dlc_two_bodyparts(dummy_logger):
     """
     Test the add_position function where the DeepLabCut h5 file has position data 
@@ -123,9 +73,8 @@ def test_add_dlc_two_bodyparts(dummy_logger):
     test_data_dir = Path("tests/test_data/downloaded/IM-1478/07252022")
 
     metadata = {}
-    metadata["datetime"] = datetime.strptime("07252022", "%m%d%Y").replace(tzinfo=ZoneInfo("America/Los_Angeles")) 
     metadata["video"] = {}
-    metadata["video"]["video_file_path"] = test_data_dir / "Behav_Vid0.avi"
+    metadata["video"]["pixels_per_cm"] = 2.688
     metadata["video"]["video_timestamps_file_path"] = test_data_dir / "testvidtimes0.csv"
     metadata["video"]["dlc_path"] = test_data_dir / "Behav_Vid0DLC_resnet50_Triangle_Maze_EphysDec7shuffle1_800000.h5"
 
@@ -195,26 +144,21 @@ def test_add_position_with_incomplete_metadata(capsys, dummy_logger):
     # 1. Test with no 'video' key
     metadata = {}
 
-    # Call the add_position function with no 'video' key in metadata and see there are no errors
+    # Call the add_position function with no 'video' key in metadata and see that we return with no errors
     add_position(nwbfile=nwbfile, metadata=metadata, logger=dummy_logger)
-    
-    
+
     # 2. Test with 'video' key and no 'dlc_path' or 'hex_centroids_file_path'
     metadata["video"] = {}
-    metadata["datetime"] = datetime.strptime("07252022", "%m%d%Y").replace(tzinfo=ZoneInfo("America/Los_Angeles")) 
 
     # Call the add_position function
     add_position(nwbfile=nwbfile, metadata=metadata, logger=dummy_logger)
     captured = capsys.readouterr() # capture stdout
 
     # Check that the correct messages were printed to stdout
-    assert "No subfield 'hex_centroids_file_path' found in video metadata!" in captured.out
     assert "No DeepLabCut (DLC) metadata found for this session. Skipping DLC conversion." in captured.out
-    
-    
+
     # 3. Test with 'video' key and 'dlc_path', but no 'video_timestamps_file_path'
     metadata["video"] = {}
-    metadata["datetime"] = datetime.strptime("07252022", "%m%d%Y").replace(tzinfo=ZoneInfo("America/Los_Angeles")) 
     metadata["video"]["dlc_path"] = (
         "tests/test_data/downloaded/IM-1478/07252022/Behav_Vid0DLC_resnet50_Triangle_Maze_EphysDec7shuffle1_800000.h5"
     )

--- a/tests/test_convert_position.py
+++ b/tests/test_convert_position.py
@@ -16,7 +16,7 @@ def test_add_dlc_one_bodypart(dummy_logger):
 
     metadata = {}
     metadata["video"] = {}
-    metadata["video"]["pixels_per_cm"] = 2.688
+    metadata["pixels_per_cm"] = 2.688
     metadata["video"]["video_timestamps_file_path"] = test_data_dir / "testvidtimes0.csv"
     metadata["video"]["dlc_path"] = test_data_dir / "Behav_Vid0DLC_resnet50_Triangle_Maze_PhotFeb12shuffle1_800000.h5"
 
@@ -74,7 +74,7 @@ def test_add_dlc_two_bodyparts(dummy_logger):
 
     metadata = {}
     metadata["video"] = {}
-    metadata["video"]["pixels_per_cm"] = 2.688
+    metadata["pixels_per_cm"] = 2.688
     metadata["video"]["video_timestamps_file_path"] = test_data_dir / "testvidtimes0.csv"
     metadata["video"]["dlc_path"] = test_data_dir / "Behav_Vid0DLC_resnet50_Triangle_Maze_EphysDec7shuffle1_800000.h5"
 

--- a/tests/test_convert_video.py
+++ b/tests/test_convert_video.py
@@ -1,8 +1,85 @@
 from datetime import datetime
 from dateutil import tz
+from zoneinfo import ZoneInfo
 from pynwb import NWBFile
+from pathlib import Path
+from ndx_franklab_novela import CameraDevice
+from hdmf.common.table import DynamicTable, VectorData
 
-from jdb_to_nwb.convert_video import add_video
+from jdb_to_nwb.convert_video import add_video, add_hex_centroids, add_camera
+
+
+def test_add_hex_centroids(dummy_logger):
+    """
+    Test the add_hex_centroids function
+    """
+
+    test_data_dir = Path("tests/test_data/downloaded/IM-1478/07252022")
+
+    metadata = {}
+    metadata["video"] = {}
+    metadata["video"]["pixels_per_cm"] = 3.14
+    metadata["video"]["hex_centroids_file_path"] = test_data_dir / "hex_coordinates_IM-1478_07252022.csv"
+
+    nwbfile = NWBFile(
+        session_description="Mock session",
+        session_start_time=datetime.now(tz.tzlocal()),
+        identifier="mock_session",
+    )
+
+    # Add centroids table to the nwb
+    add_hex_centroids(nwbfile=nwbfile, metadata=metadata, logger=dummy_logger)
+
+    # Check that behavior processing module has been added
+    assert "behavior" in nwbfile.processing
+
+    # Check that the "hex_centroids" table exists in the behavior processing module
+    behavior_module = nwbfile.processing["behavior"]
+    assert "hex_centroids" in behavior_module.data_interfaces
+    hex_centroids_table = behavior_module.data_interfaces["hex_centroids"]
+
+    assert isinstance(hex_centroids_table, DynamicTable)
+    assert hex_centroids_table.name == "hex_centroids"
+    assert hex_centroids_table.description == "Centroids of each hex in the maze (in video pixel coordinates)"
+
+    # The table should have data for all 49 hex centroids
+    assert len(hex_centroids_table) == 49
+
+    # Check that the table contains the correct columns
+    for column in hex_centroids_table.columns:
+        assert isinstance(column, VectorData)
+    expected_columns = {"hex", "x", "y", "x_meters", "y_meters"}
+    assert set(hex_centroids_table.colnames) == expected_columns, (
+        f"Hex centroid columns {set(hex_centroids_table.colnames)} "
+        f"did not match expected {expected_columns}"
+    )
+
+
+def test_add_camera(dummy_logger):
+    """
+    Test the add_camera function
+    """
+
+    metadata = {}
+    metadata["video"] = {}
+    metadata["video"]["pixels_per_cm"] = 3.14
+
+    nwbfile = NWBFile(
+        session_description="Mock session",
+        session_start_time=datetime.now(tz.tzlocal()),
+        identifier="mock_session",
+    )
+
+    # Add a CameraDevice to the nwb
+    add_camera(nwbfile=nwbfile, metadata=metadata)
+
+    # Check that the CameraDevice has been added
+    assert "camera_device 1" in nwbfile.devices
+    camera_device = nwbfile.devices["camera_device 1"]
+    assert isinstance(camera_device, CameraDevice)
+    assert camera_device.camera_name == "maze_camera"
+    assert camera_device.meters_per_pixel == metadata["video"]["pixels_per_cm"]
+    assert camera_device.manufacturer == "Logitech"
 
 
 def test_add_video(dummy_logger):
@@ -12,6 +89,7 @@ def test_add_video(dummy_logger):
     metadata["video"] = {}
     metadata["video"]["video_file_path"] = "tests/test_data/downloaded/IM-1478/07252022/Behav_Vid0.avi"
     metadata["video"]["video_timestamps_file_path"] = "tests/test_data/downloaded/IM-1478/07252022/testvidtimes0.csv"
+    metadata["datetime"] = datetime.strptime("07252022", "%m%d%Y").replace(tzinfo=ZoneInfo("America/Los_Angeles")) 
 
     test_output_video_path = "tests/test_data/downloaded/output/test_video.mp4"
 
@@ -74,6 +152,7 @@ def test_add_video_with_incomplete_metadata(capsys, dummy_logger):
 
     # Create a test metadata dictionary with a video field but no video data
     metadata["video"] = {}
+    metadata["datetime"] = datetime.strptime("07252022", "%m%d%Y").replace(tzinfo=ZoneInfo("America/Los_Angeles")) 
 
     # Call the add_video function with 'video' key in metadata, but no video subfields
     add_video(nwbfile=nwbfile, metadata=metadata, 
@@ -84,3 +163,4 @@ def test_add_video_with_incomplete_metadata(capsys, dummy_logger):
     # This should print with no error, because it is ok if we have 'video' but not these subfields, 
     # because maybe we only have DLC and not raw video
     assert "Skipping video file conversion" in captured.out
+    assert "No subfield 'hex_centroids_file_path' found in video metadata!" in captured.out

--- a/tests/test_convert_video.py
+++ b/tests/test_convert_video.py
@@ -154,6 +154,12 @@ def test_add_video_with_incomplete_metadata(capsys, dummy_logger):
     # Create a test metadata dictionary with a video field but no video data
     metadata["video"] = {}
     metadata["datetime"] = datetime.strptime("07252022", "%m%d%Y").replace(tzinfo=ZoneInfo("America/Los_Angeles")) 
+    
+    nwbfile = NWBFile(
+        session_description="Mock session",
+        session_start_time=datetime.now(tz.tzlocal()),
+        identifier="mock_session",
+    )
 
     # Call the add_video function with 'video' key in metadata, but no video subfields
     add_video(nwbfile=nwbfile, metadata=metadata, 

--- a/tests/test_convert_video.py
+++ b/tests/test_convert_video.py
@@ -17,8 +17,8 @@ def test_add_hex_centroids(dummy_logger):
     test_data_dir = Path("tests/test_data/downloaded/IM-1478/07252022")
 
     metadata = {}
+    metadata["pixels_per_cm"] = 3.14
     metadata["video"] = {}
-    metadata["video"]["pixels_per_cm"] = 3.14
     metadata["video"]["hex_centroids_file_path"] = test_data_dir / "hex_coordinates_IM-1478_07252022.csv"
 
     nwbfile = NWBFile(
@@ -62,7 +62,7 @@ def test_add_camera(dummy_logger):
 
     metadata = {}
     metadata["video"] = {}
-    metadata["video"]["pixels_per_cm"] = 3.14
+    metadata["pixels_per_cm"] = 3.14
 
     nwbfile = NWBFile(
         session_description="Mock session",
@@ -78,7 +78,7 @@ def test_add_camera(dummy_logger):
     camera_device = nwbfile.devices["camera_device 1"]
     assert isinstance(camera_device, CameraDevice)
     assert camera_device.camera_name == "maze_camera"
-    assert camera_device.meters_per_pixel == 0.01 / metadata["video"]["pixels_per_cm"]
+    assert camera_device.meters_per_pixel == 0.01 / metadata["pixels_per_cm"]
     assert camera_device.manufacturer == "Logitech"
 
 
@@ -131,6 +131,7 @@ def test_add_video_with_incomplete_metadata(capsys, dummy_logger):
 
     # Create a test metadata dictionary with no video key
     metadata = {}
+    metadata["datetime"] = datetime.strptime("07252022", "%m%d%Y").replace(tzinfo=ZoneInfo("America/Los_Angeles")) 
 
     # Create a test NWBFile
     nwbfile = NWBFile(

--- a/tests/test_convert_video.py
+++ b/tests/test_convert_video.py
@@ -78,7 +78,7 @@ def test_add_camera(dummy_logger):
     camera_device = nwbfile.devices["camera_device 1"]
     assert isinstance(camera_device, CameraDevice)
     assert camera_device.camera_name == "maze_camera"
-    assert camera_device.meters_per_pixel == metadata["video"]["pixels_per_cm"]
+    assert camera_device.meters_per_pixel == 0.01 / metadata["video"]["pixels_per_cm"]
     assert camera_device.manufacturer == "Logitech"
 
 


### PR DESCRIPTION
Resolves #99
Edits for spyglass compatibility:
- minor updates to task epochs, add an associated CameraDevice for each epoch so spyglass correctly populates the TaskEpoch table
- reorganize add_position and add_video so add_video comes first and handles hex centroids, camera metadata, and automatic assignment of pixels_per_cm based on date. add_position is DLC only.
- update tests for add_position and add_video to reflect reorganization
- do pixels_per_cm and camera stuff before adding video so the TaskEpoch table in spyglass is fine even if we don't convert video etc. maybe clean that up? idk

Resolves #98 
for consistency with Frank Lab