### PR TITLE
Separate timestamp alignment, add ephys logging

### DIFF
--- a/src/jdb_to_nwb/convert.py
+++ b/src/jdb_to_nwb/convert.py
@@ -155,12 +155,12 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
     )
 
     # Add photometry. Returns a dict with 'photometry_start' and 'port_visits' for alignment
-    photometry_data_dict = add_photometry(nwbfile=nwbfile, metadata=metadata, fig_dir=fig_dir, logger=logger)
+    photometry_data_dict = add_photometry(nwbfile=nwbfile, metadata=metadata, logger=logger, fig_dir=fig_dir)
     metadata["photometry_visit_times"] = photometry_data_dict.get("port_visits")
     photometry_start = photometry_data_dict.get('photometry_start')
 
     # Add ephys. Returns a dict with 'ephys_start' and 'port_visits' for alignment
-    ephys_data_dict = add_raw_ephys(nwbfile=nwbfile, metadata=metadata, fig_dir=fig_dir)
+    ephys_data_dict = add_raw_ephys(nwbfile=nwbfile, metadata=metadata, logger=logger, fig_dir=fig_dir)
     metadata["ephys_visit_times"] = ephys_data_dict.get("port_visits")
     ephys_start = ephys_data_dict.get('ephys_start')
 

--- a/src/jdb_to_nwb/convert.py
+++ b/src/jdb_to_nwb/convert.py
@@ -176,7 +176,7 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
     add_position(nwbfile=nwbfile, metadata=metadata, logger=logger)
 
     # Add spikes
-    add_spikes(nwbfile=nwbfile, metadata=metadata)
+    add_spikes(nwbfile=nwbfile, metadata=metadata, logger=logger)
 
     # If we have an exact photometry start time, use that as the session start time
     if photometry_start is not None:

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -930,4 +930,8 @@ def add_photometry(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
             "If you are using pyPhotometry, you must include 'ppd_file_path'."
         )
 
+    # Photometry visit times are now our ground truth visit times
+    metadata["ground_truth_time_source"] = "photometry"
+    metadata["ground_truth_visit_times"] = photometry_data_dict.get("port_visits")
+
     return photometry_data_dict

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -703,9 +703,8 @@ def process_and_add_labview_to_nwb(nwbfile: NWBFile, signals, logger):
     # Subtract the respective airPLS baseline from the smoothed signal and reference
     print("Subtracting the smoothed baseline...")
     logger.info("Subtracting the smoothed baseline...")
-    remove = 0  # Number of samples to remove from the beginning of the signals
-    baseline_subtracted_ref = reference[remove:] - ref_baseline[remove:]
-    baseline_subtracted_green = signal_green[remove:] - green_baseline[remove:]
+    baseline_subtracted_ref = reference - ref_baseline
+    baseline_subtracted_green = signal_green - green_baseline
 
     # Standardize by Z-scoring the signals (assumes signals are Gaussian distributed)
     print("Standardizing the signals by Z-scoring...")

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -146,7 +146,7 @@ def process_pulses(box):
     start = np.where(diff_data < -1)[0][0]
     pulses = np.where(diff_data > 1)[0]
     visits = pulses - start
-    return visits
+    return visits, start
 
 
 def lockin_detection(input_signal, exc1, exc2, Fs, tau=10, filter_order=5, detrend=False, full=True):
@@ -201,8 +201,14 @@ def lockin_detection(input_signal, exc1, exc2, Fs, tau=10, filter_order=5, detre
     return sig1, sig2
 
 
-def run_lockin_detection(phot, logger):
-    """Run lockin detection to extract the modulated photometry signals"""
+def run_lockin_detection(phot, start, logger):
+    """Run lockin detection to extract the modulated photometry signals
+    
+    Args:
+    phot (dict): Dictionary of photometry data
+    start (int): Number of samples to remove from the start of photometry signals
+    for alignment
+    """
     # Default args for lockin detection
     tau = 10
     filter_order = 5
@@ -232,12 +238,10 @@ def run_lockin_detection(phot, logger):
     )
 
     # Cut off the beginning of the signals to match behavioral data
-    # NOTE: We no longer do this - it will likely be removed in a future PR but keeping it for posterity for now
-    remove = 0  # Number of samples to remove from the beginning of the signals
-    sig1 = sig1[remove:]
-    sig2 = sig2[remove:]
-    ref = ref[remove:]
-    ref2 = ref2[remove:]
+    sig1 = sig1[start:]
+    sig2 = sig2[start:]
+    ref = ref[start:]
+    ref2 = ref2[start:]
 
     loc = phot["channels"][2]["location"][:15]  # First 15 characters of the location
     logger.debug(f"The location of the fiber is: {loc}")
@@ -279,11 +283,14 @@ def process_raw_labview_photometry_signals(phot_file_path, box_file_path, logger
             continue
         logger.debug(f"{box_key}: {box_dict[box_key]}")
 
-    # Run lockin detection to extract the modulated photometry signals
-    signals = run_lockin_detection(phot_dict, logger)
-
     # Get timestamps of port visits in 10 kHz photometry sample time
-    visits = process_pulses(box_dict)
+    # And the start sample of the photometry signal
+    visits, start = process_pulses(box_dict)
+
+    # Run lockin detection to extract the modulated photometry signals
+    signals = run_lockin_detection(phot_dict, start, logger)
+
+    # Add visit times to the signals dict
     signals["visits"] = visits
 
     # Convert Labview photometry start time to datetime object and set timezone to Pacific Time

--- a/src/jdb_to_nwb/convert_position.py
+++ b/src/jdb_to_nwb/convert_position.py
@@ -243,7 +243,8 @@ def add_position(nwbfile: NWBFile, metadata: dict, logger):
     pixels_per_cm = metadata["pixels_per_cm"]
 
     # If we already have aligned video timestamps, use those
-    if "video_files" in nwbfile.processing and "behavior_video" in nwbfile.processing["video_files"]:
+    video_files = nwbfile.processing.get("video_files", None) 
+    if video_files and isinstance(video_files, dict) and "behavior_video" in video_files:
         # Pynwb will link the timestamps here instead of creating a new array! Cool!
         true_video_timestamps = nwbfile.processing["video_files"]["behavior_video"]
 

--- a/src/jdb_to_nwb/convert_position.py
+++ b/src/jdb_to_nwb/convert_position.py
@@ -4,6 +4,7 @@ import pandas as pd
 from pynwb import NWBFile, TimeSeries
 from pynwb.behavior import Position
 from scipy.interpolate import interp1d
+from .timestamps_alignment import align_via_interpolation
 
 
 def read_dlc(deeplabcut_file_path, pixels_per_cm, logger, likelihood_cutoff=0.9, cam_fps=15):
@@ -241,45 +242,40 @@ def add_position(nwbfile: NWBFile, metadata: dict, logger):
     # it was automatically assigned based on session date in convert_video
     pixels_per_cm = metadata["pixels_per_cm"]
 
-    # Read timestamps of each camera frame (in ms)
-    video_timestamps_file_path = metadata["video"]["video_timestamps_file_path"]
-    with open(video_timestamps_file_path, "r") as video_timestamps_file:
-        video_timestamps_ms = np.array(list(csv.reader(video_timestamps_file)), dtype=float).ravel()
+    # If we already have aligned video timestamps, use those
+    if "video_files" in nwbfile.processing and "behavior_video" in nwbfile.processing["video_files"]:
+        # Pynwb will link the timestamps here instead of creating a new array! Cool!
+        true_video_timestamps = nwbfile.processing["video_files"]["behavior_video"]
 
-    # Adjust video timestamps so photometry starts at time 0 and convert to seconds to match NWB standard
-    video_timestamps_ms = np.subtract(video_timestamps_ms, metadata.get("photometry_start_in_arduino_ms", 0))
-    video_timestamps_seconds = video_timestamps_ms / 1000
-
-    # Align video timestamps to photometry/ephys
-    ground_truth_visit_times = metadata.get("photometry_visit_times", metadata.get("ephys_visit_times"))
-    arduino_visit_times = metadata.get("arduino_visit_times")
-
-    if ground_truth_visit_times is not None:
-        logger.info("Aligning DLC timestamps...")
-        # Make sure we have the same number of arduino and ground truth visit times for alignment
-        assert len(arduino_visit_times) == len(ground_truth_visit_times), (
-            f"Expected the same number of port visits recorded by arduino and ephys/photometry! \n"
-            f"Got {len(arduino_visit_times)} arduino visits, "
-            f"but {len(ground_truth_visit_times)} visits for alignment!"
-        )
-        # Align video timestamps via interpolation. For timestamps out of visit bounds, 
-        # use the ratio of spacing between arduino_visit_times and ground_truth_visit_times
-        true_video_timestamps = np.interp(
-            x=video_timestamps_seconds,
-            xp=arduino_visit_times,
-            fp=ground_truth_visit_times,
-            left=ground_truth_visit_times[0] + 
-                (video_timestamps_seconds[0] - arduino_visit_times[0]) * 
-                (ground_truth_visit_times[1] - ground_truth_visit_times[0]) / 
-                (arduino_visit_times[1] - arduino_visit_times[0]),
-            right=ground_truth_visit_times[-1] + 
-                (video_timestamps_seconds[-1] - arduino_visit_times[-1]) * 
-                (ground_truth_visit_times[-1] - ground_truth_visit_times[-2]) / 
-                (arduino_visit_times[-1] - arduino_visit_times[-2])
-        )
+    # Otherwise read timestamps of each camera frame (in ms) and align them
     else:
-        # If we don't have port visits for alignment, keep the original timestamps
-        true_video_timestamps = video_timestamps_seconds
+        video_timestamps_file_path = metadata["video"]["video_timestamps_file_path"]
+        with open(video_timestamps_file_path, "r") as video_timestamps_file:
+            video_timestamps_ms = np.array(list(csv.reader(video_timestamps_file)), dtype=float).ravel()
+            
+        # Adjust video timestamps so photometry starts at time 0 (this is also done to match arduino visit times)
+        video_timestamps_ms = np.subtract(video_timestamps_ms, metadata.get("photometry_start_in_arduino_ms", 0))
+
+        # Convert video timestamps to seconds to match NWB standard
+        video_timestamps_seconds = video_timestamps_ms / 1000
+
+        # Get port visits in video time (aka arduino time)
+        arduino_visit_times = metadata.get("arduino_visit_times")
+
+        # If we have ground truth port visit times, align video timestamps to that
+        ground_truth_time_source = metadata.get("ground_truth_time_source")
+        if ground_truth_time_source is not None:
+
+            logger.info(f"Aligning position (video) timestamps to ground truth ({ground_truth_time_source})")
+            ground_truth_visit_times = metadata.get("ground_truth_visit_times")
+            true_video_timestamps = align_via_interpolation(unaligned_timestamps=video_timestamps_seconds,
+                                                    unaligned_visit_times=arduino_visit_times,
+                                                    ground_truth_visit_times=ground_truth_visit_times,
+                                                    logger=logger)
+        else:
+            # If we don't have port visits for alignment, keep the original timestamps
+            logger.info("No ground truth port visits found, keeping original position (video) timestamps.")
+            true_video_timestamps = video_timestamps_seconds
 
     print("Adding position data from DeepLabCut...")
     logger.info("Adding position data from DeepLabCut...")

--- a/src/jdb_to_nwb/convert_raw_ephys.py
+++ b/src/jdb_to_nwb/convert_raw_ephys.py
@@ -17,6 +17,8 @@ from neuroconv.tools.spikeinterface.spikeinterfacerecordingdatachunkiterator imp
 from pynwb import NWBFile
 from pynwb.ecephys import ElectricalSeries
 from spikeinterface.extractors import OpenEphysBinaryRecordingExtractor
+
+from .timestamps_alignment import align_via_interpolation
 from .plotting.plot_ephys import plot_channel_map
 
 MICROVOLTS_PER_VOLT = 1e6
@@ -37,11 +39,13 @@ CHANNEL_MAP_PATH = RESOURCES_DIR / "channel_map.csv"
 ELECTRODE_COORDS_PATH_3MM_PROBE = RESOURCES_DIR / "3mm_probe_66um_pitch_electrode_coords.csv"
 ELECTRODE_COORDS_PATH_6MM_PROBE = RESOURCES_DIR / "6mm_probe_80um_pitch_electrode_coords.csv"
 
+
 def add_electrode_data(
     *,
     nwbfile: NWBFile,
     filtering_list: list[str],
     metadata: dict,
+    logger,
     fig_dir: Path = None,
 ):
     """
@@ -55,6 +59,8 @@ def add_electrode_data(
         The filtering applied to each channel.
     metadata : dict
         Metadata dictionary.
+    logger: logger
+        Logger to track conversion progress
     fig_dir : Path, optional
         The directory to save the figure. If None, the figure will not be saved.
     """
@@ -68,6 +74,7 @@ def add_electrode_data(
     device = nwbfile.create_device(**device_args)
 
     electrodes_location = metadata["ephys"].get("electrodes_location")
+    logger.info(f"Electrodes location is {electrodes_location}")
 
     # Create an NWB ElectrodeGroup for all electrodes
     # TODO: confirm that all electrodes are in the same group
@@ -96,12 +103,14 @@ def add_electrode_data(
         f"Impedance file has columns {electrode_data.columns.tolist()}, "
         f"does not match expected columns {expected_columns}"
     )
+    logger.debug(f"Impedance file has expected columns {expected_columns}")
     
     # Check that the filtering list has the same length as the number of channels
     assert len(filtering_list) == len(electrode_data), (
         f"Filtering list does not have the same length ({len(filtering_list)}) "
-        "as the number of channels ({len(electrode_data)})."
+        f"as the number of channels ({len(electrode_data)})."
     )
+    logger.debug(f"Filtering list has the same length ({len(filtering_list)}) as number of channels")
 
     # Drop the first column which should be the same as the second column
     assert (
@@ -111,17 +120,23 @@ def add_electrode_data(
 
     # Get the channel map based on how the rat was plugged in (assume "chip_first" if none specified)
     plug_order = metadata["ephys"].get("plug_order", "chip_first")
+    logger.info(f"Plug order is: {plug_order}")
+
     channel_map_df = pd.read_csv(CHANNEL_MAP_PATH)
     channel_map = np.array(channel_map_df[plug_order])
 
     # Get electrode coordinates as a (2, 256) array based on the probe name
     # The first column is the relative x coordinate, and the second column is the relative y coordinate
     probe_name = metadata["ephys"]["device"].get("name")
+    logger.info(f"Probe name is: {probe_name}")
     if "3mm" in probe_name:
+        logger.info(f"Using electrode coords for 3mm probe at {ELECTRODE_COORDS_PATH_3MM_PROBE}")
         channel_geometry = pd.read_csv(ELECTRODE_COORDS_PATH_3MM_PROBE)
     elif "6mm" in probe_name:
+        logger.info(f"Using electrode coords for 6mm probe at {ELECTRODE_COORDS_PATH_6MM_PROBE}")
         channel_geometry = pd.read_csv(ELECTRODE_COORDS_PATH_6MM_PROBE)
     else:
+        logger.error(f"Expected either '3mm' or '6mm' in device name '{probe_name}'")
         raise ValueError(f"Expected either '3mm' or '6mm' in device name '{probe_name}'")
 
     assert len(channel_geometry) == len(channel_map) == len(electrode_data), (
@@ -130,6 +145,7 @@ def add_electrode_data(
         f"channel_map ({len(channel_map)}), "
         f"electrode_data ({len(electrode_data)})"
     )
+    logger.debug(f"Length of channel geometry, channel map, and electrode data matches (length={len(channel_map)})!")
 
     plot_channel_map(probe_name, channel_map, channel_geometry, fig_dir=fig_dir)
     
@@ -143,6 +159,7 @@ def add_electrode_data(
 
     # Mark electrodes with impedance that is less than 0.1 MOhms or more than 3.0 MOhms
     # as bad electrodes
+    logger.info(f"Marking channels with impedance>{MAX_IMPEDANCE_OHMS} or <{MIN_IMPEDANCE_OHMS} as 'bad_channel'")
     electrode_data["bad_channel"] = (
         electrode_data["Impedance Magnitude at 1000 Hz (ohms)"] < MIN_IMPEDANCE_OHMS) | (
         electrode_data["Impedance Magnitude at 1000 Hz (ohms)"] > MAX_IMPEDANCE_OHMS
@@ -211,13 +228,14 @@ def add_electrode_data(
         )
 
 
-def get_port_visits(folder_path: Path):
+def get_port_visits(folder_path: Path, logger):
     """
     Extract port visit times from OpenEphys channel ADC1
 
     Args:
         folder_path: Path to the folder containing the OpenEphys binary recording. The folder
             should contain subfolders leading to a file named 'continuous.dat'
+        logger: Logger to track conversion progress
 
     Returns:
         list: list of port visit times in seconds
@@ -235,12 +253,16 @@ def get_port_visits(folder_path: Path):
     # Memory-map the large .dat file to avoid loading everything into memory. Reshape to (samples, channels)
     file_path = folder_path + "/experiment1/recording1/continuous/Rhythm_FPGA-100.0/continuous.dat"
     data_for_all_channels = np.memmap(file_path, dtype='int16',mode='c').reshape(-1, total_channels) 
+    
+    logger.debug(f"Reading Open Ephys port visits from channel {port_visits_channel_num}")
+    logger.debug(f"Downsampling data to from {openephys_fs} Hz to {downsampled_fs} Hz so it isn't huge")
 
     # Extract the channel that records port visits and downsample so the data isn't massive
     visits_channel_data = data_for_all_channels[:, port_visits_channel_num]
     visits_channel_data = visits_channel_data[::int(openephys_fs / downsampled_fs)]
 
     # Find indices where the visits channel is high (aka port visit times)
+    logger.debug(f"Recording times the channel is high (>{pulse_high_threshold})")
     pulse_above_threshold = np.where(visits_channel_data > pulse_high_threshold)[0]
 
     # If no port visits were found, return an empty list
@@ -254,15 +276,21 @@ def get_port_visits(folder_path: Path):
     pulse_starts = np.insert(pulse_above_threshold[breaks], 0, pulse_above_threshold[0])
     pulse_ends = np.append(pulse_above_threshold[breaks - 1], pulse_above_threshold[-1])
     pulse_durations = pulse_ends - pulse_starts + 1 
+    
+    logger.debug(f"Found {len(pulse_starts)} visit pulses.")
 
     # Only keep pulses at least 5ms long just in case (typical port visit keeps the channel high for ~10ms)
     min_pulse_duration = int(downsampled_fs * 0.005)
     pulse_starts = pulse_starts[pulse_durations > min_pulse_duration]
 
+    logger.debug(f"Only keeping pulses at least 5ms long ({min_pulse_duration} samples at {downsampled_fs} Hz).")
+    logger.debug(f"Kept {len(pulse_starts)} pulses.")
+    logger.debug(f"Pulse durations: {pulse_durations}")
+
     # Align to first pulse (which marks photometry(?) start time) and convert to seconds
     # NOTE: The duration of the first pulse is longer than a normal pulse (~500ms instead of ~10ms)
     # should we add a check for this to ensure we have identified the correct "start" pulse?
-    # Maybe just log its duration when we add logging?
+    logger.info(f"Removing the first ephys pulse, as it marks start time and not a true port visit")
     port_visits = pulse_starts[1:] - pulse_starts[0]
     port_visits = [float(visit / downsampled_fs) for visit in port_visits]
     return port_visits
@@ -270,6 +298,7 @@ def get_port_visits(folder_path: Path):
 
 def get_raw_ephys_data(
     folder_path: Path,
+    logger
 ) -> tuple[SpikeInterfaceRecordingDataChunkIterator, float, np.ndarray, list[str]]:
     """
     Get the raw ephys data from the OpenEphys binary recording.
@@ -277,6 +306,7 @@ def get_raw_ephys_data(
     Args:
         folder_path: Path to the folder containing the OpenEphys binary recording. The folder
             should have the date in the name and contain a file called "settings.xml".
+        logger: Logger to track conversion progress
 
     Returns:
         traces_as_iterator: SpikeInterfaceRecordingDataChunkIterator, to be used as the
@@ -295,15 +325,18 @@ def get_raw_ephys_data(
     channel_ids_to_convert = [ch for ch in recording.channel_ids if ch.startswith("CH")]
     recording_sliced = recording.select_channels(channel_ids=channel_ids_to_convert)
 
+    logger.debug(f"Found {len(channel_ids_to_convert)} Open Ephys channels to convert: {channel_ids_to_convert}")
+
     # Get the channel conversion factor
     channel_conversion_factors_uv = recording_sliced.get_channel_gains()
     # Warn if the channel conversion factors are not the same for all channels
     if not all(channel_conversion_factors_uv == channel_conversion_factors_uv[0]):
-        warnings.warn(
+        logger.warning(
             "The channel conversion factors are not the same for all channels. "
             "This is unexpected and may indicate a problem with the conversion factors."
         )
     channel_conversion_factor_v = channel_conversion_factors_uv[0] * VOLTS_PER_MICROVOLT
+    logger.debug(f"Channel conversion factor in V: {channel_conversion_factor_v}")
 
     # NOTE channel offsets should be 0 for all channels in openephys data
     channel_conversion_offsets = recording_sliced.get_channel_offsets()
@@ -312,8 +345,7 @@ def get_raw_ephys_data(
     # Get the original timestamps (in seconds)
     original_timestamps = recording_sliced.get_times()
 
-    # TODO when we add logging, log sample frequency
-    # recording.get_sampling_frequency()
+    logger.debug(f"Open Ephys sampling frequency: {recording.get_sampling_frequency()}")
 
     # Create a SpikeInterfaceRecordingDataChunkIterator using all default buffering and
     # chunking options. This will be passed to the pynwb.ecephys.ElectricalSeries
@@ -333,9 +365,11 @@ def get_raw_ephys_data(
     settings_root = settings_tree.getroot()
     rhfp_processor = settings_root.find(".//PROCESSOR[@name='Sources/Rhythm FPGA']")
     if rhfp_processor is None:
+        logger.error("Could not find the Rhythm FPGA processor in the settings.xml file.")
         raise ValueError("Could not find the Rhythm FPGA processor in the settings.xml file.")
     channel_info = rhfp_processor.find("CHANNEL_INFO")
     if channel_info is None:
+        logger.error("Could not find the CHANNEL_INFO node in the settings.xml file.")
         raise ValueError("Could not find the CHANNEL_INFO node in the settings.xml file.")
     channel_number_to_channel_name = {
         channel.attrib["number"]: channel.attrib["name"] for channel in channel_info.findall("CHANNEL")
@@ -367,6 +401,7 @@ def get_raw_ephys_data(
             else:
                 filtering[channel.attrib["number"]] = "No filtering"
     else:
+        logger.error("No bandpass filter found in the settings.xml file.")
         raise ValueError("No bandpass filter found in the settings.xml file.")
 
     # Check that the channel numbers in filtering go from "0" to "N-1"
@@ -378,8 +413,8 @@ def get_raw_ephys_data(
 
     # Warn if the channel filtering is not the same for all channels
     if not all(f == filtering_list[0] for f in filtering_list):
-        warnings.warn(
-            "WARNING: The channel filtering is not the same for all channels. "
+        logger.warning(
+            "The channel filtering is not the same for all channels. "
             "This is unexpected and may indicate a problem with the filtering settings."
         )
 
@@ -398,7 +433,8 @@ def get_raw_ephys_data(
 def add_raw_ephys(
     *,
     nwbfile: NWBFile,
-    metadata: dict = None,
+    metadata: dict,
+    logger,
     fig_dir: Path = None,
 ) -> None:
     """Add the raw ephys data to a NWB file. Must be called after add_electrode_groups
@@ -407,14 +443,17 @@ def add_raw_ephys(
     ----------
     nwbfile : NWBFile
         The NWB file being assembled.
-    metadata : dict, optional
-        Metadata dictionary,by default None
+    metadata : dict
+        Metadata dictionary
+    logger: Logger
+        Logger to track conversion progress
     fig_dir: Path, optional
         The directory to save the figure. If None, the figure will not be saved.
     """
 
     if "ephys" not in metadata:
         print("No ephys metadata found for this session. Skipping ephys conversion.")
+        logger.info("No ephys metadata found for this session. Skipping ephys conversion.")
         return {}
 
     # If we do have "ephys" in metadata, check for the required keys
@@ -426,36 +465,48 @@ def add_raw_ephys(
             "Remove the 'ephys' field from metadata if you do not have ephys data "
             f"for this session, \nor specify the following missing subfields:{missing_keys}"
         )
+        logger.warning(
+            "The required ephys subfields do not exist in the metadata dictionary.\n"
+            "Remove the 'ephys' field from metadata if you do not have ephys data "
+            f"for this session, \nor specify the following missing subfields:{missing_keys}"
+        )
         return {}
 
     print("Adding raw ephys...")
+    logger.info("Adding raw ephys...")
     openephys_folder_path = metadata["ephys"]["openephys_folder_path"]
 
     # Get Open Ephys start time as datetime object based on the time specified in the path
     datetime_str = openephys_folder_path.split('/')[-1] # The path ends with the date and time
     open_ephys_start = datetime.strptime(datetime_str, "%Y-%m-%d_%H-%M-%S")
     open_ephys_start = open_ephys_start.replace(tzinfo=ZoneInfo("America/Los_Angeles"))
+    logger.info(f"Open Ephys start time: {open_ephys_start}")
 
     (
         traces_as_iterator,
         channel_conversion_factor_v,
         original_timestamps,
         filtering_list,
-    ) = get_raw_ephys_data(openephys_folder_path)
+    ) = get_raw_ephys_data(openephys_folder_path, logger)
     num_samples, num_channels = traces_as_iterator.maxshape
     
     # Get port visits recorded by Open Ephys for timestamp alignment
-    ephys_visit_times = get_port_visits(openephys_folder_path)
+    ephys_visit_times = get_port_visits(openephys_folder_path, logger)
     print(f"Open Ephys recorded {len(ephys_visit_times)} port visits.")
+    logger.info(f"Open Ephys recorded {len(ephys_visit_times)} port visits.")
+    logger.debug(f"Open Ephys port visits: {ephys_visit_times}")
 
     # Create electrode groups and add electrode data to the NWB file
-    add_electrode_data(nwbfile=nwbfile, filtering_list=filtering_list, metadata=metadata, fig_dir=fig_dir)
+    add_electrode_data(nwbfile=nwbfile, filtering_list=filtering_list, 
+                       metadata=metadata, logger=logger, fig_dir=fig_dir)
 
     # Check that the number of electrodes in the NWB file is the same as the number of channels in traces_as_iterator
     assert (len(nwbfile.electrodes) == num_channels), (
         f"Number of electrodes in NWB file ({len(nwbfile.electrodes)}) does not match number of channels "
         f"in traces_as_iterator ({num_channels})."
     )
+    logger.debug(f"There are {len(nwbfile.electrodes)} electrodes in the nwbfile "
+                 "(same as number of channels in traces_as_iterator)")
 
     # Create the electrode table region encompassing all electrodes
     electrode_table_region = nwbfile.create_electrode_table_region(
@@ -474,34 +525,25 @@ def add_raw_ephys(
         compression="gzip",
     )
 
-    # If we have visit times from photometry, align timestamps to that
-    # Based on: https://github.com/catalystneuro/neuroconv/blob/8d274f434c152d34ea0bcc5d120765639c6771a7/src/
-    # neuroconv/datainterfaces/text/timeintervalsinterface.py#L192
-    photometry_visit_times = metadata.get("photometry_visit_times")
-    if photometry_visit_times is not None:
-        # Make sure we have the same number of ephys and photometry visit times
-        assert len(ephys_visit_times) == len(photometry_visit_times), (
-            f"Expected the same number of port visits recorded by ephys and photometry! \n"
-            f"Got {len(ephys_visit_times)} ephys visits, but {len(photometry_visit_times)} photometry visits!!!"
-        )
-        # Align ephys timestamps to photometry via interpolation. For timestamps out of visit bounds, 
-        # use the ratio of spacing between ephys_visit_times and photometry_visit_times
-        ephys_timestamps = np.interp(
-            x=original_timestamps,
-            xp=ephys_visit_times,
-            fp=photometry_visit_times,
-            left=photometry_visit_times[0] + 
-                (original_timestamps[0] - ephys_visit_times[0]) * 
-                (photometry_visit_times[1] - photometry_visit_times[0]) / 
-                (ephys_visit_times[1] - ephys_visit_times[0]),
-            right=photometry_visit_times[-1] + 
-                (original_timestamps[-1] - ephys_visit_times[-1]) * 
-                (photometry_visit_times[-1] - photometry_visit_times[-2]) / 
-                (ephys_visit_times[-1] - ephys_visit_times[-2])
-        )
+    # If we have ground truth port visit times (photometry), align timestamps to that
+    ground_truth_time_source = metadata.get("ground_truth_time_source")
+    if ground_truth_time_source is not None:
+
+        logger.info(f"Aligning ephys visit times to ground truth ({ground_truth_time_source})")
+        ground_truth_visit_times = metadata.get("ground_truth_visit_times")
+        ephys_timestamps = align_via_interpolation(unaligned_timestamps=original_timestamps,
+                                                   unaligned_visit_times=ephys_visit_times,
+                                                   ground_truth_visit_times=ground_truth_visit_times,
+                                                   logger=logger)
     else:
         # If we don't have photometry, keep the original timestamps
         ephys_timestamps = original_timestamps
+        logger.info("No ground truth visit times (photometry) found. "
+                    "Ephys visit times are now our ground truth visit times.")
+
+        # Ephys visit times are now our ground truth visit times
+        metadata["ground_truth_time_source"] = "ephys"
+        metadata["ground_truth_visit_times"] = ephys_visit_times
 
     # Create the ElectricalSeries
     # For now, we do not chunk or compress the timestamps, which are relatively small
@@ -515,6 +557,7 @@ def add_raw_ephys(
     )
 
     # Add the ElectricalSeries to the NWBFile
+    logger.info("Adding raw ephys to the nwbfile as an ElectricalSeries")
     nwbfile.add_acquisition(eseries)
 
     return {"ephys_start": open_ephys_start, "port_visits": ephys_visit_times}

--- a/src/jdb_to_nwb/convert_raw_ephys.py
+++ b/src/jdb_to_nwb/convert_raw_ephys.py
@@ -2,7 +2,6 @@
 # ndx-franklab-novela extension to store the Probe information for maximal integration with Spyglass, 
 # so we are doing the conversion manually using PyNWB.
 
-import warnings
 from datetime import datetime
 from zoneinfo import ZoneInfo
 import xml.etree.ElementTree as ET
@@ -290,7 +289,7 @@ def get_port_visits(folder_path: Path, logger):
     # Align to first pulse (which marks photometry(?) start time) and convert to seconds
     # NOTE: The duration of the first pulse is longer than a normal pulse (~500ms instead of ~10ms)
     # should we add a check for this to ensure we have identified the correct "start" pulse?
-    logger.info(f"Removing the first ephys pulse, as it marks start time and not a true port visit")
+    logger.info("Removing the first ephys pulse, as it marks start time and not a true port visit")
     port_visits = pulse_starts[1:] - pulse_starts[0]
     port_visits = [float(visit / downsampled_fs) for visit in port_visits]
     return port_visits

--- a/src/jdb_to_nwb/convert_raw_ephys.py
+++ b/src/jdb_to_nwb/convert_raw_ephys.py
@@ -2,6 +2,8 @@
 # ndx-franklab-novela extension to store the Probe information for maximal integration with Spyglass, 
 # so we are doing the conversion manually using PyNWB.
 
+import os
+import glob
 from datetime import datetime
 from zoneinfo import ZoneInfo
 import xml.etree.ElementTree as ET
@@ -250,7 +252,9 @@ def get_port_visits(folder_path: Path, logger):
     # For reference, a typical port visit keeps the channel high for ~10ms, so 10 samples at 1000 Hz
 
     # Memory-map the large .dat file to avoid loading everything into memory. Reshape to (samples, channels)
-    file_path = folder_path + "/experiment1/recording1/continuous/Rhythm_FPGA-100.0/continuous.dat"
+    # file_path will be something like "/experiment1/recording1/continuous/Rhythm_FPGA-100.0/continuous.dat"
+    pattern = os.path.join(folder_path, "experiment*/recording*/continuous/*/continuous.dat")
+    file_path = glob.glob(pattern)[0] 
     data_for_all_channels = np.memmap(file_path, dtype='int16',mode='c').reshape(-1, total_channels) 
     
     logger.debug(f"Reading Open Ephys port visits from channel {port_visits_channel_num}")

--- a/src/jdb_to_nwb/convert_spikes.py
+++ b/src/jdb_to_nwb/convert_spikes.py
@@ -2,16 +2,18 @@ from .mdasortinginterface import MdaSortingInterface
 from pynwb import NWBFile
 
 
-def add_spikes(nwbfile: NWBFile, metadata: dict):
+def add_spikes(nwbfile: NWBFile, metadata: dict, logger):
     
     if "ephys" not in metadata:
         return
     
     if not ("mountain_sort_output_file_path" in metadata["ephys"] and "sampling_frequency" in metadata["ephys"]):
         print("No spike sorting metadata found for this session. Skipping spike conversion.")
+        logger.info("No spike sorting metadata found for this session. Skipping spike conversion.")
         return
 
     print("Adding spikes...")
+    logger.info("Adding spikes...")
     mountain_sort_output_file_path = metadata["ephys"]["mountain_sort_output_file_path"]
     sampling_frequency = metadata["ephys"]["sampling_frequency"]
 

--- a/src/jdb_to_nwb/convert_video.py
+++ b/src/jdb_to_nwb/convert_video.py
@@ -197,7 +197,7 @@ def add_video(nwbfile: NWBFile, metadata: dict, output_video_path, logger):
         return None
 
     if "hex_centroids_file_path" in metadata["video"]:
-        add_hex_centroids(nwbfile=nwbfile, metadata=metadata, pixels_per_cm=pixels_per_cm, logger=logger)
+        add_hex_centroids(nwbfile=nwbfile, metadata=metadata, logger=logger)
     else:
         print("No subfield 'hex_centroids_file_path' found in video metadata! Skipping adding hex centroids.")
         logger.warning("No subfield 'hex_centroids_file_path' found in video metadata! Skipping adding hex centroids.")

--- a/src/jdb_to_nwb/timestamps_alignment.py
+++ b/src/jdb_to_nwb/timestamps_alignment.py
@@ -6,7 +6,7 @@ def trim_sync_pulses(ground_truth_visits, unaligned_visits, logger):
     """
     We may have an unequal number of sync pulses (port visit times) recorded by different datastreams
     (photometry vs ephys vs arduino), if one datastream was started (or ended) before (or after) another 
-    and port visits occured during this time. Typically, this occurs when photometry was started before
+    and port visits occurred during this time. Typically, this occurs when photometry was started before
     ephys/behavior (e.g. IM-1478, 07/19/2022). If this is the case, trim the longer list of port visits
     so both lists are the same length and can be used for timestamps alignment. We auto-detect if the 
     visits to be removed are at the start or the end of the longer list by matching the relative spacing 

--- a/src/jdb_to_nwb/timestamps_alignment.py
+++ b/src/jdb_to_nwb/timestamps_alignment.py
@@ -1,0 +1,105 @@
+import numpy as np
+from scipy.interpolate import interp1d
+
+
+def trim_sync_pulses(visits_1, visits_2, logger):
+    """
+    We may have an unequal number of sync pulses (port visit times) recorded by different datastreams
+    (photometry vs ephys vs arduino), if one datastream was started (or ended) before (or after) another 
+    and port visits occured during this time. Typically, this occurs when photometry was started before
+    ephys/behavior (e.g. IM-1478, 07/19/2022). If this is the case, trim the longer list of port visits
+    so both lists are the same length and can be used for timestamps alignment. We auto-detect if the 
+    visits to be removed are at the start or the end of the longer list by matching the relative spacing 
+    between port visit times for each datastream.
+    
+    Args:
+    visits_1 (list or np.array): List of ground truth port visit times
+    visits_2 (list or np.array): List of unaligned port visit times
+
+    Returns:
+    aligned_timestamps (list or np.array): Timestamps aligned to the ground_truth_visit_times
+    """
+
+    # Ensure both lists are arrays
+    visits_1, visits_2 = np.array(visits_1), np.array(visits_2)
+    logger.info(f"Initial number of port visits: ground truth={len(visits_1)}, unaligned={len(visits_2)}")
+
+    # Determine which list is longer
+    if len(visits_1) > len(visits_2):
+        long_list, short_list = visits_1, visits_2
+        logger.debug("List of ground truth visits is longer; trimming it.")
+    else:
+        long_list, short_list = visits_2, visits_1
+        logger.debug("List of unaligned visits is longer; trimming it.")
+
+    # Get the spacing between pulses for each list
+    long_diffs = np.diff(long_list)
+    short_diffs = np.diff(short_list)
+
+    # Find the best start index for the long list.
+    # The best starting index is the one that best matches the relative spacing of pulses for each list.
+    min_error = float("inf")
+    best_start = 0
+
+    logger.info("Finding best alignment between port visits by minimizing error in pulse spacing.")
+
+    for i in range(len(long_diffs) - len(short_diffs) + 1):
+        error = np.sum(np.abs(long_diffs[i:i+len(short_diffs)] - short_diffs))
+        logger.debug(f"Trimming {i} samples from longer list. Sum of differences in pulse spacing={error}")
+        if error < min_error:
+            min_error = error
+            best_start = i
+
+    logger.info(f"Best alignment is found by trimming {best_start} samples from the longer list (error={min_error})")
+
+    # We generally expect the error to be minimized by exclusively trimming pulses 
+    # from the beginning of the longer list (because one datastream was started earlier). 
+    # Warn if this isn't the case.
+    expected_best_start = len(long_diffs) - len(short_diffs)
+    if best_start != expected_best_start:
+        logger.warning(f"Expected best alignment to be found by removing {expected_best_start} samples "
+                       f"from the start of the longer list, but got best alignment removing {best_start} samples!")
+        logger.warning("Check differences in pulse spacing in the DEBUG log to make sure this is correct, "
+                       "and/or confirm this matches known experimental choices \n"
+                       "(e.g. this would be the case if a datastream was stopped earlier instead of started later)")
+
+    # Trim the longer list to match the length of the shorter list
+    trimmed_list = long_list[best_start:best_start + len(short_list)]
+
+    # Ensure correct order of return values
+    return (trimmed_list, short_list) if len(visits_1) > len(visits_2) else (short_list, trimmed_list)
+
+
+def align_via_interpolation(unaligned_timestamps, unaligned_visit_times, ground_truth_visit_times, logger):
+    """
+    Align timestamps to ground truth timestamps via interpolation using port visit times as sync pulses.
+    Timestamps that fall before the first port visit or after the last port visit will be aligned via extrapolation.
+
+    Args:
+    unaligned_timestamps (list or np.array): List of timestamps to align
+    unaligned_visit_times (list or np.array): List of port visit times (in the same time base as unaligned timestamps) 
+    ground_truth_visit_times (list or np.array): List of ground truth port visit times (to be aligned to)
+    logger: Logger to record timestamp alignment
+
+    Returns:
+    aligned_timestamps (list or np.array): Timestamps aligned to the ground_truth_visit_times
+    """
+    
+    # Check that we have the same number of ground truth visit times and unaligned visit times
+    # If we don't, warn the user and fix it so we can proceed with alignment
+    if len(ground_truth_visit_times) != len(unaligned_visit_times):
+        logger.warning(f"There are {len(ground_truth_visit_times)} ground truth visit times but "
+                       f"{len(unaligned_visit_times)} unaligned visit times!")
+        logger.warning("The longer list will be trimmed by matching relative spacing between visits.")
+        ground_truth_visit_times, unaligned_visit_times = trim_sync_pulses(ground_truth_visit_times, 
+                                                                           unaligned_visit_times, logger)
+    else:
+        logger.debug(f"There are {len(unaligned_visit_times)} visit times to be used for alignment.")
+
+    # Create an interpolation function to go from unaligned visit times to ground truth visit times
+    # Extrapolate timestamps that fall before the first visit or after the last visit
+    logger.info("Aligning timestamps to ground truth port visit times via linear interpolation")
+    interp_func = interp1d(unaligned_visit_times, ground_truth_visit_times, kind='linear', fill_value='extrapolate')
+    aligned_timestamps = interp_func(unaligned_timestamps)
+
+    return aligned_timestamps

--- a/tests/test_convert_spikes.py
+++ b/tests/test_convert_spikes.py
@@ -5,7 +5,7 @@ from pynwb import NWBFile
 from jdb_to_nwb.convert_spikes import add_spikes
 
 
-def test_add_spikes():
+def test_add_spikes(dummy_logger):
     """
     Test the add_spikes function.
 
@@ -23,7 +23,7 @@ def test_add_spikes():
         identifier="mock_session",
     )
 
-    add_spikes(nwbfile, metadata)
+    add_spikes(nwbfile=nwbfile, metadata=metadata, logger=dummy_logger)
 
     assert len(nwbfile.units) == 17
     assert nwbfile.units["spike_times"] is not None
@@ -33,7 +33,7 @@ def test_add_spikes():
     assert len(nwbfile.units.spike_times.data) == 30  # Check total number of spikes
 
 
-def test_add_spikes_with_incomplete_metadata(capsys):
+def test_add_spikes_with_incomplete_metadata(dummy_logger, capsys):
     """
     Test that the add_spikes function responds appropriately to missing or incomplete metadata.
     
@@ -57,12 +57,12 @@ def test_add_spikes_with_incomplete_metadata(capsys):
     # If we call the add_spikes function with no 'ephys' key in metadata,
     # it should skip ephys conversion and return with no errors
     # (No output because we have already printed that we are skipping ephys in add_raw_ephys)
-    add_spikes(nwbfile=nwbfile, metadata=metadata)
+    add_spikes(nwbfile=nwbfile, metadata=metadata, logger=dummy_logger)
 
     # Create a test metadata dictionary with an ephys field but no spike data
     metadata["ephys"] = {}
 
-    add_spikes(nwbfile=nwbfile, metadata=metadata)
+    add_spikes(nwbfile=nwbfile, metadata=metadata, logger=dummy_logger)
     captured = capsys.readouterr() # capture stdout
 
     # Check that the correct message was printed to stdout


### PR DESCRIPTION
A lot happens here:
Resolves #91 and resolves #94 to complete and clean up timestamp alignment.

Photometry sets metadata fields `ground_truth_visit_times` and `ground_truth_time_source` if it exists. Otherwise ephys sets these fields. These are used for timestamps alignment (for ephys to photometry, and behavior to ground truth, and video/position to ground truth), which is now separated into its own module.

This improves upon past alignment code because it extrapolates for timestamps before the first port visit or after the last port visit (`np.interp` doesn't do that).

Note that this makes returning "photometry_visit_times" and "ephys_visit_times" and storing these in metadata obsolete. I'll remove those in a future PR.

While we're here...
Resolves #77 - we add logging for timestamps alignment, so it's a good time to add logging for ephys/spikes anyway
Resolves #87 - fix path 