### PR TITLE
Update photometry devices metadata in resources

### DIFF
--- a/resources/photometry_devices.yaml
+++ b/resources/photometry_devices.yaml
@@ -1,20 +1,38 @@
 # A running list of devices used for photometry. Reference individual devices by name in the metadata yaml file.
 
 excitation_sources:
-  - name: Purple LED
+  - name: Blue LED
     excitation_wavelength_in_nm: 470.0
+    manufacturer: ThorLabs
+    model: M470F3 
+    illumination_type: LED
+  - name: Purple LED
+    excitation_wavelength_in_nm: 405.0
     manufacturer: ThorLabs
     model: M405FP1
     illumination_type: LED
-  - name: Blue LED
+
+# excitation sources for Doric minicube: 
+# https://neuro.doriclenses.com/products/fmc7?productoption%5BPort%20Configuration%5D=Built-in%20LED%20and%20DETECTOR
+  - name: Doric Blue LED
+    excitation_wavelength_in_nm: 470.0
+    manufacturer: Doric
+    model: ilFMC7-G2
+    illumination_type: LED
+  - name: Doric Purple LED
     excitation_wavelength_in_nm: 405.0
-    manufacturer: ThorLabs
-    model: M470F3
+    manufacturer: Doric
+    model: ilFMC7-G2
+    illumination_type: LED
+  - name: Doric Green LED
+    excitation_wavelength_in_nm: 565.0
+    manufacturer: Doric
+    model: ilFMC7-G2
     illumination_type: LED
 
 optic_fibers:
   - name: Optic Fiber
-    numerical_aperture: 0.39  # TODO get correct value for this
+    numerical_aperture: 0.66  # TODO get correct value for this
     core_diameter_in_um: 200.0
 
 photodetectors:
@@ -23,3 +41,9 @@ photodetectors:
     model: "2151"
     detector_type: Silicon PIN photodiode
     detected_wavelength_in_nm: 0.0  # TODO modify extension to allow range (320-1050 nm)
+
+  - name: Doric ilFMC7-G2 (Integrated LED Fluorescence Mini Cube 5 ports Gen.2)
+    manufacturer: Doric
+    model: "ilFMC7-G2"
+    detector_type: Silicon photodiode
+    detected_wavelength_in_nm: 960.0 # TODO modify extension to allow range (320-1050 nm) currently peak wavelength

--- a/src/jdb_to_nwb/convert.py
+++ b/src/jdb_to_nwb/convert.py
@@ -111,7 +111,7 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
     subject = Subject(**metadata["subject"])
 
     # Create session_id in {rat}_{date} format where date is YYYYMMDD
-    session_id = f"{metadata.get("animal_name")}_{metadata.get("datetime").strftime("%Y%m%d")}"
+    session_id = f"{metadata.get('animal_name')}_{metadata.get('datetime').strftime('%Y%m%d')}"
 
     # Create directory for associated figures
     fig_dir = Path(output_nwb_dir) / f"{session_id}_figures"
@@ -192,7 +192,7 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
     # Otherwise keep the default start time (00:00:00 Pacific Time on the session date)
     else:
         logger.warning("No photometry or ephys start time found, \nso session_start_time is the default start time: "
-                       f"{nwbfile.fields["session_start_time"]} (00:00:00 Pacific Time on the session date)")
+                       f"{nwbfile.fields['session_start_time']} (00:00:00 Pacific Time on the session date)")
 
     # Set the timestamps reference time equal to the session start time
     nwbfile.fields["timestamps_reference_time"] = nwbfile.fields["session_start_time"]

--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -398,17 +398,17 @@ def test_add_photometry_metadata(dummy_logger):
         )
 
     assert "Purple LED" in nwbfile.devices
-    assert nwbfile.devices["Purple LED"].excitation_wavelength_in_nm == 470.0
+    assert nwbfile.devices["Purple LED"].excitation_wavelength_in_nm == 405.0
     assert nwbfile.devices["Purple LED"].illumination_type == "LED"
     assert nwbfile.devices["Purple LED"].manufacturer == "ThorLabs"
     assert nwbfile.devices["Purple LED"].model == "M405FP1"
     assert "Blue LED" in nwbfile.devices
-    assert nwbfile.devices["Blue LED"].excitation_wavelength_in_nm == 405.0
+    assert nwbfile.devices["Blue LED"].excitation_wavelength_in_nm == 470.0
     assert nwbfile.devices["Blue LED"].illumination_type == "LED"
     assert nwbfile.devices["Blue LED"].manufacturer == "ThorLabs"
     assert nwbfile.devices["Blue LED"].model == "M470F3"
     assert "Optic Fiber" in nwbfile.devices
-    assert nwbfile.devices["Optic Fiber"].numerical_aperture == 0.39
+    assert nwbfile.devices["Optic Fiber"].numerical_aperture == 0.66
     assert nwbfile.devices["Optic Fiber"].core_diameter_in_um == 200.0
     assert "Newport Femtowatt Photoreceiver" in nwbfile.devices
     assert nwbfile.devices["Newport Femtowatt Photoreceiver"].manufacturer == "Newport"


### PR DESCRIPTION
Add correct metadata for Jose to photometry resources

Also, fix some minor formatting issues with single/double quotes in f strings so older python versions don't complain