### PR TITLE
Update photometry_devices.yaml

### DIFF
--- a/resources/photometry_devices.yaml
+++ b/resources/photometry_devices.yaml
@@ -1,5 +1,7 @@
 # A running list of devices used for photometry. Reference individual devices by name in the metadata yaml file.
 
+# These are the excitation sources for the old maze room.
+# These are used in combination with the Doric ilFMC7 photodetector.
 excitation_sources:
   - name: Blue LED
     excitation_wavelength_in_nm: 470.0
@@ -12,8 +14,8 @@ excitation_sources:
     model: M405FP1
     illumination_type: LED
 
-# excitation sources for Doric minicube: 
-# https://neuro.doriclenses.com/products/fmc7?productoption%5BPort%20Configuration%5D=Built-in%20LED%20and%20DETECTOR
+# These are the excitation sources for the new maze room.
+# These are built-in to the Doric ilFMC7-G2 minicube.
   - name: Doric Blue LED
     excitation_wavelength_in_nm: 470.0
     manufacturer: Doric
@@ -31,19 +33,31 @@ excitation_sources:
     illumination_type: LED
 
 optic_fibers:
-  - name: Optic Fiber
-    numerical_aperture: 0.66  # TODO get correct value for this
+  - name: Doric 0.6mm Flat 40mm Optic Fiber
+    numerical_aperture: 0.66
     core_diameter_in_um: 200.0
+    manufacturer: Doric
+    model: MFC_200/250-0.66_40mm_MF2.5_FLT
+
+  - name: Doric 0.6mm Flat 10mm Optic Fiber
+    numerical_aperture: 0.66
+    core_diameter_in_um: 200.0
+    manufacturer: Doric
+    model: MFC_200/250-0.66_10mm_MF2.5_FLT
 
 photodetectors:
-  - name: Newport Femtowatt Photoreceiver
-    manufacturer: Newport
-    model: "2151"
-    detector_type: Silicon PIN photodiode
-    detected_wavelength_in_nm: 0.0  # TODO modify extension to allow range (320-1050 nm)
-
+# This is the photodetector for the old maze room.
+  - name: Doric iFMC7-G2 (7 ports Fluorescence Mini Cube - Three Fluorophores)
+    manufacturer: Doric
+    model: "iFMC7-G2"
+    detector_type: Silicon photodiode
+    detected_wavelength_in_nm: 960.0 # TODO modify extension to allow range (320-1050 nm) currently peak wavelength
+    description: https://neuro.doriclenses.com/products/fmc7?productoption%5BPort%20Configuration%5D=Built-in%20DETECTOR
+    
+# This is the photodetector for the new maze room.
   - name: Doric ilFMC7-G2 (Integrated LED Fluorescence Mini Cube 5 ports Gen.2)
     manufacturer: Doric
     model: "ilFMC7-G2"
     detector_type: Silicon photodiode
     detected_wavelength_in_nm: 960.0 # TODO modify extension to allow range (320-1050 nm) currently peak wavelength
+    description: https://neuro.doriclenses.com/products/fmc7?productoption%5BPort%20Configuration%5D=Built-in%20LED%20and%20DETECTOR

--- a/resources/photometry_devices.yaml
+++ b/resources/photometry_devices.yaml
@@ -33,13 +33,13 @@ excitation_sources:
     illumination_type: LED
 
 optic_fibers:
-  - name: Doric 0.6mm Flat 40mm Optic Fiber
+  - name: Doric 0.66mm Flat 40mm Optic Fiber
     numerical_aperture: 0.66
     core_diameter_in_um: 200.0
     manufacturer: Doric
     model: MFC_200/250-0.66_40mm_MF2.5_FLT
 
-  - name: Doric 0.6mm Flat 10mm Optic Fiber
+  - name: Doric 0.66mm Flat 10mm Optic Fiber
     numerical_aperture: 0.66
     core_diameter_in_um: 200.0
     manufacturer: Doric

--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -408,15 +408,17 @@ def test_add_photometry_metadata(dummy_logger):
     assert nwbfile.devices["Blue LED"].manufacturer == "ThorLabs"
     assert nwbfile.devices["Blue LED"].model == "M470F3"
     assert "Doric 0.66mm Flat 40mm Optic Fiber" in nwbfile.devices
-    assert nwbfile.devices["Doric 0.66mm Flat 40mm Optic Fiber"].numerical_aperture == 0.66
-    assert nwbfile.devices["Doric 0.66mm Flat 40mm Optic Fiber"].core_diameter_in_um == 200.0
-    assert nwbfile.devices["Doric 0.66mm Flat 40mm Optic Fiber"].manufacturer == "Doric"
-    assert nwbfile.devices["Doric 0.66mm Flat 40mm Optic Fiber"].model == "MFC_200/250-0.66_40mm_MF2.5_FLT"
+    optic_fiber = nwbfile.devices["Doric 0.66mm Flat 40mm Optic Fiber"]
+    assert optic_fiber.numerical_aperture == 0.66
+    assert optic_fiber.core_diameter_in_um == 200.0
+    assert optic_fiber.manufacturer == "Doric"
+    assert optic_fiber.model == "MFC_200/250-0.66_40mm_MF2.5_FLT"
     assert "Doric iFMC7-G2 (7 ports Fluorescence Mini Cube - Three Fluorophores)" in nwbfile.devices
-    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].manufacturer == "Doric"
-    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].model == "iFMC7-G2"
-    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].detector_type == "Silicon photodiode"
-    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].detected_wavelength_in_nm == 960.0
+    photodetector = nwbfile.devices["Doric iFMC7-G2 (7 ports Fluorescence Mini Cube - Three Fluorophores)"]
+    assert photodetector.manufacturer == "Doric"
+    assert photodetector.model == "iFMC7-G2"
+    assert photodetector.detector_type == "Silicon photodiode"
+    assert photodetector.detected_wavelength_in_nm == 960.0
 
 
 def test_add_photometry_with_incomplete_metadata(capsys, dummy_logger):

--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -20,10 +20,10 @@ def add_dummy_photometry_metadata_to_metadata(metadata):
         "Purple LED",
     ]
     metadata["photometry"]["optic_fibers"] = [
-        "Optic Fiber",
+        "Doric 0.66mm Flat 40mm Optic Fiber",
     ]
     metadata["photometry"]["photodetectors"] = [
-        "Newport Femtowatt Photoreceiver",
+        "Doric iFMC7-G2 (7 ports Fluorescence Mini Cube - Three Fluorophores)",
     ]
     # metadata["photometry"]["optic_fiber_implant_sites"] = []
     # metadata["photometry"]["viruses"] = []
@@ -373,10 +373,10 @@ def test_add_photometry_metadata(dummy_logger):
         "Blue LED",
     ]
     metadata["photometry"]["optic_fibers"] = [
-        "Optic Fiber",
+        "Doric 0.66mm Flat 40mm Optic Fiber",
     ]
     metadata["photometry"]["photodetectors"] = [
-        "Newport Femtowatt Photoreceiver",
+        "Doric iFMC7-G2 (7 ports Fluorescence Mini Cube - Three Fluorophores)",
     ]
 
     # Create a test NWBFile
@@ -407,14 +407,16 @@ def test_add_photometry_metadata(dummy_logger):
     assert nwbfile.devices["Blue LED"].illumination_type == "LED"
     assert nwbfile.devices["Blue LED"].manufacturer == "ThorLabs"
     assert nwbfile.devices["Blue LED"].model == "M470F3"
-    assert "Optic Fiber" in nwbfile.devices
-    assert nwbfile.devices["Optic Fiber"].numerical_aperture == 0.66
-    assert nwbfile.devices["Optic Fiber"].core_diameter_in_um == 200.0
-    assert "Newport Femtowatt Photoreceiver" in nwbfile.devices
-    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].manufacturer == "Newport"
-    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].model == "2151"
-    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].detector_type == "Silicon PIN photodiode"
-    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].detected_wavelength_in_nm == 0.0
+    assert "Doric 0.66mm Flat 40mm Optic Fiber" in nwbfile.devices
+    assert nwbfile.devices["Doric 0.66mm Flat 40mm Optic Fiber"].numerical_aperture == 0.66
+    assert nwbfile.devices["Doric 0.66mm Flat 40mm Optic Fiber"].core_diameter_in_um == 200.0
+    assert nwbfile.devices["Doric 0.66mm Flat 40mm Optic Fiber"].manufacturer == "Doric"
+    assert nwbfile.devices["Doric 0.66mm Flat 40mm Optic Fiber"].model == "MFC_200/250-0.66_40mm_MF2.5_FLT"
+    assert "Doric iFMC7-G2 (7 ports Fluorescence Mini Cube - Three Fluorophores)" in nwbfile.devices
+    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].manufacturer == "Doric"
+    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].model == "iFMC7-G2"
+    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].detector_type == "Silicon photodiode"
+    assert nwbfile.devices["Newport Femtowatt Photoreceiver"].detected_wavelength_in_nm == 960.0
 
 
 def test_add_photometry_with_incomplete_metadata(capsys, dummy_logger):


### PR DESCRIPTION
Update photometry devices metadata (and tests) to reflect the photodetectors and optic fibers we actually use