### PR TITLE
Add checks/tests for general metadata, improve date flexibility

### DIFF
--- a/src/jdb_to_nwb/convert.py
+++ b/src/jdb_to_nwb/convert.py
@@ -207,7 +207,7 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
     logger.info(f"Original metadata file path was {metadata_file_path}")
     logger.info(f"Saved a copy of metadata to {metadata_copy_file_path}")
 
-    # Set default lab, insitution, and experiment_description if unspecified
+    # Set default lab, institution, and experiment_description if unspecified
     set_default_metadata(metadata, logger)
 
     # Parse subject metadata

--- a/src/jdb_to_nwb/convert.py
+++ b/src/jdb_to_nwb/convert.py
@@ -107,9 +107,9 @@ def set_default_metadata(metadata, logger):
     # Set defaults if these fields are missing
     if "institution" not in metadata:
         metadata["institution"] = "University of California, San Francisco"
-        logger.warning("No 'insitution' found in metadata, "
+        logger.warning("No 'institution' found in metadata, "
                        "setting to default 'University of California, San Francisco'")
-        print("No 'insitution' found in metadata, setting to default 'University of California, San Francisco'")
+        print("No 'institution' found in metadata, setting to default 'University of California, San Francisco'")
     if "lab" not in metadata:
         metadata["lab"] = "Berke Lab"
         logger.warning("No 'lab' found in metadata, setting to default 'Berke Lab'")

--- a/src/jdb_to_nwb/convert.py
+++ b/src/jdb_to_nwb/convert.py
@@ -25,13 +25,23 @@ def to_datetime(date_str):
     Return a datetime object from a date string in MMDDYYYY or YYYYMMDD format.
     Set the HH:MM:SS time to 00:00:00 Pacific Time.
     """
+    # If it's already a datetime, we're good to go
+    if isinstance(date_str, datetime):
+        return date_str
 
-    # Convert to string if it's an int, and add a leading 0 if needed
-    # If things get weird here, just specify the date as a string in the first place
-    date_str = str(date_str).zfill(8)
+    # Try ISO format first (e.g. "2024-01-22T00:00:00-08:00")
+    if "T" in str(date_str):
+        try:
+            dt = datetime.fromisoformat(str(date_str))
+            return dt.astimezone(ZoneInfo("America/Los_Angeles"))
+        except (ValueError, TypeError, AttributeError):
+            pass  # If ISO parsing fails, continue with other formats
 
     # Remove slashes and dashes so we can handle formats like MM/DD/YYYY, MM-DD-YYYY, etc
-    date_str = date_str.replace("/", "").replace("-", "")
+    date_str = str(date_str).replace("/", "").replace("-", "").strip()
+
+    # Add a leading 0 if needed (if date_str was specified as an int, leading 0s get clipped)
+    date_str = date_str.zfill(8)
 
     if len(date_str) != 8:
         raise ValueError("Date string must be exactly 8 characters long. "
@@ -48,6 +58,66 @@ def to_datetime(date_str):
     dt = datetime.strptime(date_str, date_format)
     dt = dt.replace(tzinfo=ZoneInfo("America/Los_Angeles"))
     return dt
+
+
+def check_required_metadata(metadata):
+    """
+    Make sure all required basic metadata fields are present before doing conversion to nwb.
+    """
+
+    # Break if these fields are missing!!
+    assert "experimenter" in metadata, (
+        "Required field 'experimenter' not found in metadata!! Add this field and re-run conversion."
+    )
+    assert "date" in metadata, (
+        "Required field 'date' not found in metadata!! Add this field and re-run conversion."
+    )
+    assert "subject" in metadata, (
+        "Required field 'subject' not found in metadata!! Add this field and re-run conversion."
+    )
+    # Make sure subject has the required subfields
+    subject_fields = set(metadata.get("subject").keys())
+    required_subject_fields = {"subject_id", "species", "genotype", "sex", "description"}
+    missing_subject_fields = required_subject_fields - subject_fields
+    assert not missing_subject_fields, (
+        f"Required subfields {missing_subject_fields} not found in subject metadata! "
+        "Add these fielda and re-run conversion"
+    )
+    assert "age" in subject_fields or "date_of_birth" in subject_fields, (
+        "Required subfield 'age' or 'date_of_birth' not found in subject metadata! "
+        "Add one of these fields and re-run conversion. ('date_of_birth' is strongly preferred)"
+    )
+    # If date_of_birth is specified as a string, convert to a datetime object to make nwb happy
+    # They are working on fixing this, so this will eventually be removed
+    if "date_of_birth" in subject_fields:
+        metadata["subject"]["date_of_birth"] = to_datetime(metadata.get("subject").get("date_of_birth"))
+
+    # If animal_name not set in metadata, set it to subject_id.
+    # We do this here instead of in set_default_metadata because animal_name needed
+    # to name the file and set up logging
+    if "animal_name" not in metadata:
+        metadata["animal_name"] = metadata["subject"]["subject_id"]
+
+
+def set_default_metadata(metadata, logger):
+    """
+    Set default values for some metadata fields if they are not specified in the metadata file.
+    Log this at WARNING level.
+    """
+    # Set defaults if these fields are missing
+    if "institution" not in metadata:
+        metadata["institution"] = "University of California, San Francisco"
+        logger.warning("No 'insitution' found in metadata, "
+                       "setting to default 'University of California, San Francisco'")
+        print("No 'insitution' found in metadata, setting to default 'University of California, San Francisco'")
+    if "lab" not in metadata:
+        metadata["lab"] = "Berke Lab"
+        logger.warning("No 'lab' found in metadata, setting to default 'Berke Lab'")
+        print("No 'lab' found in metadata, setting to default 'Berke Lab'")
+    if "experiment_description" not in metadata:
+        metadata["experiment_description"] = "Hex maze task"
+        logger.warning("No 'experiment_description' found in metadata, setting to default 'Hex maze task'")
+        print("No 'experiment_description' found in metadata, setting to default 'Hex maze task'")
 
 
 def setup_logger(log_name, path_logfile_info, path_logfile_warn, path_logfile_debug) -> logging.Logger:
@@ -102,13 +172,11 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
     with open(metadata_file_path, "r") as f:
         metadata = yaml.safe_load(f)
 
-    # TODO: Add checks for required metadata?
+    # Check that required metadata fields are present before doing conversion
+    check_required_metadata(metadata)
 
     # Convert date in metadata to datetime object
     metadata["datetime"] = to_datetime(metadata.get("date"))
-
-    # Parse subject metadata
-    subject = Subject(**metadata["subject"])
 
     # Create session_id in {rat}_{date} format where date is YYYYMMDD
     session_id = f"{metadata.get('animal_name')}_{metadata.get('datetime').strftime('%Y%m%d')}"
@@ -138,6 +206,13 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
 
     logger.info(f"Original metadata file path was {metadata_file_path}")
     logger.info(f"Saved a copy of metadata to {metadata_copy_file_path}")
+
+    # Set default lab, insitution, and experiment_description if unspecified
+    set_default_metadata(metadata, logger)
+
+    # Parse subject metadata
+    subject = Subject(**metadata["subject"])
+    logger.info(f"Created subject: {subject}")
 
     nwbfile = NWBFile(
         session_description="Placeholder description",  # Placeholder: updated in add_behavior

--- a/tests/test_convert_general.py
+++ b/tests/test_convert_general.py
@@ -1,0 +1,182 @@
+import pytest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from jdb_to_nwb.convert import check_required_metadata, set_default_metadata, to_datetime
+
+
+def test_check_required_metadata_with_all_required_metadata():
+    """
+    Test that check_required_metadata runs without errors and modifies metadata in-place
+    when all required fields are present.
+    """
+    metadata = {
+        "experimenter": "Tim Krausz",
+        "date": "07/25/2022",
+        "subject": {
+            "subject_id": "IM-1478",
+            "species": "Rattus norvegicus",
+            "genotype": "Wildtype",
+            "sex": "M",
+            "description": "Long Evans Rat",
+            "date_of_birth": "1/20/2022"
+        }
+    }
+
+    # We expect no errors - all required metadata exists!
+    check_required_metadata(metadata)
+
+    # Confirm that animal_name was set to subject_id
+    assert metadata["animal_name"] == "IM-1478", (
+        f"Expected 'animal_name' to be set to 'IM-1478', got {metadata.get('animal_name')}"
+    )
+
+    # Confirm date_of_birth was converted to datetime
+    assert isinstance(metadata["subject"]["date_of_birth"], datetime), (
+        f"Expected 'date_of_birth' to be set to datetime, got {type(metadata['subject']['date_of_birth'])}"
+    )
+
+
+@pytest.mark.parametrize("missing_field", ["experimenter", "date", "subject"])
+def test_check_required_metadata_with_missing_metadata(missing_field):
+    """
+    Test that missing top-level required fields 'experimenter', 'date', or 'subject' raises an AssertionError.
+    """
+    metadata = {
+        "experimenter": "Tim Krausz",
+        "date": "07/25/2022",
+        "subject": {
+            "subject_id": "IM-1478",
+            "species": "Rattus norvegicus",
+            "genotype": "Wildtype",
+            "sex": "M",
+            "description": "Long Evans Rat",
+            "date_of_birth": "1/20/2022"
+        }
+    }
+
+    # Remove each required field to test check_required_metadata complains at us
+    metadata.pop(missing_field)
+
+    # We expect an error to be raised for each missing field
+    with pytest.raises(AssertionError, match=f"Required field '{missing_field}' not found"):
+        check_required_metadata(metadata)
+
+
+@pytest.mark.parametrize("missing_subfield", ["subject_id", "species", "genotype", "sex", "description"])
+def test_check_subject_metadata_with_missing_subfields(missing_subfield):
+    """
+    Test that missing required subfields under subject raises an AssertionError.
+    """
+    # Check that we raise an error for any missing subject subfield
+    metadata = {
+        "experimenter": "Tim Krausz",
+        "date": "07/25/2022",
+        "subject": {
+            "subject_id": "IM-1478",
+            "species": "Rattus norvegicus",
+            "genotype": "Wildtype",
+            "sex": "M",
+            "description": "Long Evans Rat",
+            "date_of_birth": "1/20/2022"
+        }
+    }
+
+    metadata["subject"].pop(missing_subfield)
+
+    with pytest.raises(AssertionError, match="Required subfields .* not found in subject metadata"):
+        check_required_metadata(metadata)
+    
+    # Check that we raise an error if either age OR date_of_birth is missing
+    metadata = {
+        "experimenter": "Tim Krausz",
+        "date": "07/25/2022",
+        "subject": {
+            "subject_id": "IM-1478",
+            "species": "Rattus norvegicus",
+            "genotype": "Wildtype",
+            "sex": "M",
+            "description": "Long Evans Rat",
+        }
+    }
+
+    with pytest.raises(AssertionError, match="Required subfield 'age' or 'date_of_birth' not found"):
+        check_required_metadata(metadata)
+
+
+def test_set_default_metadata_sets_missing_fields(dummy_logger):
+    """
+    Test that set_default_metadata sets expected default values and logs warnings for missing fields.
+    """
+    metadata = {}
+
+    set_default_metadata(metadata, dummy_logger)
+
+    # Confirm values were set
+    assert metadata["institution"] == "University of California, San Francisco", (
+        "Expected default institution to be set to 'University of California, San Francisco', "
+        f"got {metadata.get('institution')}"
+    )
+    assert metadata["lab"] == "Berke Lab", (
+        f"Expected default lab to be set to 'Berke Lab', got {metadata.get('lab')}"
+    )
+    assert metadata["experiment_description"] == "Hex maze task", (
+        "Expected default experiment_description to be set to 'Hex maze task', "
+        f"got {metadata.get('experiment_description')}"
+    )
+
+
+def test_set_default_metadata_does_not_overwrite_existing(dummy_logger):
+    """
+    Test that set_default_metadata does not overwrite fields already present in metadata.
+    """
+    metadata = {
+        "institution": "UCSF",
+        "lab": "Frank Lab",
+        "experiment_description": "Triangle maze!"
+    }
+
+    # No defaults should be set, because we specified values for institution, lab, and experiment_description
+    set_default_metadata(metadata, dummy_logger)
+
+    assert metadata["institution"] == "UCSF"
+    assert metadata["lab"] == "Frank Lab"
+    assert metadata["experiment_description"] == "Triangle maze!"
+
+
+def test_to_datetime_all_cases():
+    """
+    Check that our to_datetime function is happy to handle all cases of MMDDYYYY and YYYYMMDD  
+    (including variations MM/DD/YYYY, MM-DD-YYYY, YYYY/MM/DD, YYYY-MM-DD, or when month 
+    is a single digit, which happens when the user specifies an int date instead of a string)
+    """
+    pacific = ZoneInfo("America/Los_Angeles")
+
+    test_cases = [
+        # Test so many valid ways of specifying the same date!!!!
+        ("01222024", datetime(2024, 1, 22, tzinfo=pacific)),
+        ("1222024", datetime(2024, 1, 22, tzinfo=pacific)),
+        ("20240122", datetime(2024, 1, 22, tzinfo=pacific)),
+        ("2024-01-22", datetime(2024, 1, 22, tzinfo=pacific)),
+        ("2024/01/22", datetime(2024, 1, 22, tzinfo=pacific)),
+        ("01/22/2024", datetime(2024, 1, 22, tzinfo=pacific)),
+        ("01-22-2024", datetime(2024, 1, 22, tzinfo=pacific)),
+        ("1/22/2024", datetime(2024, 1, 22, tzinfo=pacific)),
+        ("1-22-2024", datetime(2024, 1, 22, tzinfo=pacific)),
+        # An int!
+        (1222024, datetime(2024, 1, 22, tzinfo=pacific)),
+        # Already a datetime!
+        ("2024-01-22T00:00:00-08:00", datetime(2024, 1, 22, tzinfo=pacific)),
+        (datetime(2024, 1, 22), datetime(2024, 1, 22)),
+        # These should error
+        ("12224", ValueError),
+        ("nope2024", ValueError),
+    ]
+
+    for input_val, expected in test_cases:
+        if isinstance(expected, datetime):
+            result = to_datetime(input_val)
+            assert result == expected, f"to_datetime failed for input date: {input_val}"
+        elif expected is ValueError:
+            with pytest.raises(ValueError):
+                to_datetime(input_val)


### PR DESCRIPTION
Been meaning to get to this for a while - it's about time!
Closes #60
Closes #33 

Some little things are nicer now:
- no need to specify `animal_name` if it's not different from `subject_id`! If not specified, it is automatically set to `subject_id`. But we keep the option for these to be separate because you may want to add an animal nickname to `animal_name` (e.g. "corvette"). The main difference: the output nwb file (and associated logs) are named {animal_name}_{date}, and subject_id is stored in the subject data in the nwbfile.
- when specifying subject `date_of_birth`, no need to use ISO format - any MMDDYYYY (or YYYYMMDD, MM/DD/YYYY, YYYY-MM-DD, etc etc) should be fine! Should be chill if it's a string or an int too. If you want to use ISO format anyway that's also cool! Pls use 4 digits for year though otherwise things will get confusing when it's trying to auto-detect the format)
- Same does for general field `date` - any "normal" (see above) format you wanna use should be ok
- It'll complain at you if required general metadata fields (`subject`, `date`, `experimenter`) are missing
- It'll auto-fill some metadata fields with defaults (`lab` is 'Berke Lab', `institution` is 'University of California, San Francisco', `experiment_description` is 'Hex maze task')
- Adds unit tests for all of these guys too!