### PR TITLE
Make Steph top author & maintainer, remove emails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jdb_to_nwb"
-# Emails are omitted from author list due to PyPI display issue https://github.com/pypi/warehouse/issues/12877
 authors = [
   { name="Stephanie Crater" },
   { name="Ryan Ly" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,15 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jdb_to_nwb"
+# Emails are omitted from author list due to PyPI display issue https://github.com/pypi/warehouse/issues/12877
 authors = [
-  { name="Ryan Ly", email="rly@lbl.gov" },
+  { name="Stephanie Crater" },
+  { name="Ryan Ly" },
+  { name="Yang-Sun Hwang" },
+  { name="Jose Figueroa" },
+]
+maintainers = [
   { name="Stephanie Crater", email="stephcrater@berkeley.edu" },
-  { name="Yang-Sun Hwang", email="YangSun.Hwang@ucsf.edu"},
-  { name="Jose Figueroa", email="Jose.Figueroa@ucsf.edu" },
 ]
 description = "Converts electrophysiology, photometry, and behavioral data for the hex maze task used by the Berke Lab at UCSF to NWB format for sharing and analysis."
 readme = "README.md"


### PR DESCRIPTION
PyPI has a bug (https://github.com/pypi/warehouse/issues/12877) where if the `authors` key (or the `maintainers` key) in `pyproject.toml` contains multiple name+email dicts, then only the first name-email combination is shown on the PyPI page. 
<img width="281" alt="image" src="https://github.com/user-attachments/assets/cab67732-2967-415e-9a9d-053ea941beb0" />

One workaround is to remove all email addresses from the author list. Then a list of author names should be shown with no email link. I think that's fine.

@calderast is the primary contributor and maintainer, so I updated `pyproject.toml` to reflect that. @calderast I kept your  email address in the maintainer list so that you can be reached outside of github (but feel free to remove).