### PR TITLE
Update dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "matplotlib",
     "imageio-ffmpeg",
     "ffmpeg-python",
+    "tables",  # used by pandas to read HDF5 files
     "opencv-python",
     "hex-maze-neuro",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,7 @@ dependencies = [
     "matplotlib",
     "imageio-ffmpeg",
     "ffmpeg-python",
-    "tables",
     "opencv-python",
-    "numcodecs==0.12.1",
     "hex-maze-neuro",
 ]
 dynamic = ["version"]
@@ -50,7 +48,6 @@ dev = [
     "black",
     "ruff",
     "codespell",
-    "tqdm",
 ]
 test = ["pytest", "pytest-cov"]
 


### PR DESCRIPTION
Pinning `numcodecs==0.12.1` prevents the package from being installed on Python 3.13 because numcodecs==0.12.1 cannot be built on Python 3.13. We need to use a more recent version of numcodecs (current version is 0.16.1)

But numcodecs does not seem to be used in this package, so I removed it.

`tables` is also not used in this package, so I removed it.

`tqdm` is listed in both dependencies and optional dependencies so I removed it from optional dependencies.