### PR TITLE
Store ElectricalSeries in uV, rename electrode table impedance column to imp

### DIFF
--- a/src/jdb_to_nwb/convert_raw_ephys.py
+++ b/src/jdb_to_nwb/convert_raw_ephys.py
@@ -28,9 +28,6 @@ from .timestamps_alignment import align_via_interpolation
 from .plotting.plot_ephys import plot_channel_map, plot_channel_impedances, plot_neuropixels
 from ndx_franklab_novela import AssociatedFiles, Probe, NwbElectrodeGroup, Shank, ShanksElectrode
 
-MICROVOLTS_PER_VOLT = 1e6
-VOLTS_PER_MICROVOLT = 1 / MICROVOLTS_PER_VOLT
-
 MIN_IMPEDANCE_OHMS = 1e5
 MAX_IMPEDANCE_OHMS = 3e6
 
@@ -248,7 +245,7 @@ def get_raw_ephys_data(
         traces_as_iterator (SpikeInterfaceRecordingDataChunkIterator):
             To be used as the data argument in pynwb.ecephys.ElectricalSeries.
         channel_conversion_factor (float):
-            The conversion factor from the raw data to volts.
+            The conversion factor from the raw data to uV.
         original_timestamps (np.ndarray):
             Array that could be used as the timestamps argument in pynwb.ecephys.ElectricalSeries
             or may need to be time aligned with the other data streams in the NWB file.
@@ -298,8 +295,9 @@ def get_raw_ephys_data(
             "The channel conversion factors are not the same for all channels. "
             "This is unexpected and may indicate a problem with the conversion factors."
         )
-    channel_conversion_factor_v = channel_conversion_factors_uv[0] * VOLTS_PER_MICROVOLT
-    logger.debug(f"Channel conversion factor in V: {channel_conversion_factor_v}")
+    # Just grab the first one, because it should be the same for all channels
+    channel_conversion_factor_uv = channel_conversion_factors_uv[0]
+    logger.debug(f"Channel conversion factor in uV: {channel_conversion_factor_uv}")
 
     # NOTE channel offsets should be 0 for all channels in openephys data
     channel_conversion_offsets = recording_sliced.get_channel_offsets()
@@ -317,7 +315,7 @@ def get_raw_ephys_data(
 
     return (
         traces_as_iterator,
-        channel_conversion_factor_v,
+        channel_conversion_factor_uv,
         original_timestamps,
     )
 
@@ -750,7 +748,7 @@ def add_electrode_data_berke_probe(
         description="The port of the electrode from the impedance file",
     )
     nwbfile.add_electrode_column(
-        name="impedance",
+        name="imp",
         description="The impedance of the electrode (Impedance Magnitude at 1000 Hz (ohms))",
     )
     nwbfile.add_electrode_column(
@@ -847,7 +845,7 @@ def add_electrode_data_berke_probe(
                 open_ephys_channel_str=row["open_ephys_channel_string"],
                 channel_name=row["Channel Name"],
                 port=row["Port"],
-                impedance=row["Impedance Magnitude at 1000 Hz (ohms)"],
+                imp=row["Impedance Magnitude at 1000 Hz (ohms)"],
                 imp_phase=row["Impedance Phase at 1000 Hz (degrees)"],
                 series_resistance_in_ohms=row["Series RC equivalent R (Ohms)"],
                 series_capacitance_in_farads=row["Series RC equivalent C (Farads)"],
@@ -1129,7 +1127,7 @@ def add_raw_ephys(
     # Get raw ephys data
     (
         traces_as_iterator,
-        channel_conversion_factor_v,
+        channel_conversion_factor_uv,
         original_timestamps,
     ) = get_raw_ephys_data(folder_path=openephys_folder_path, logger=logger, exclude_channels=exclude_channel_names)
     num_samples, num_channels = traces_as_iterator.maxshape
@@ -1157,6 +1155,11 @@ def add_raw_ephys(
         region=list(range(len(nwbfile.electrodes))),
         description="Electrodes used in raw ElectricalSeries recording",
     )
+    
+    # Convert to uV without loading the whole thing at once
+    def traces_in_uV_iterator(traces_as_iterator, conversion_factor):
+        for chunk in traces_as_iterator:
+            yield chunk.astype(np.float32) * conversion_factor
 
     # A chunk of shape (81920, 64) and dtype int16 (2 bytes) is ~10 MB, which is the recommended chunk size
     # by the NWB team.
@@ -1164,7 +1167,7 @@ def add_raw_ephys(
     # they require the hdf5plugin library to be installed. gzip is available by default.
     # Use gzip for now, but consider zstd/blosc-zstd in the future.
     data_data_io = H5DataIO(
-        traces_as_iterator,
+        traces_in_uV_iterator(traces_as_iterator, channel_conversion_factor_uv),
         chunks=(min(num_samples, 81920), min(num_channels, 64)),
         compression="gzip",
     )
@@ -1197,7 +1200,8 @@ def add_raw_ephys(
         data=data_data_io,
         timestamps=ephys_timestamps,
         electrodes=electrode_table_region,
-        conversion=channel_conversion_factor_v,
+        conversion=1.0,
+        unit="microvolts",
     )
 
     # Add the ElectricalSeries to the NWBFile


### PR DESCRIPTION
Spyglass ignores `ElectricalSeries` conversion factors and just assumes everything is in uV. I will submit a spyglass PR to edit this, but just storing ours in uV is a reasonable workaround for now.

While I'm messing with ephys, I figured I would fix #161 (also for spyglass compatability)