### PR TITLE
Rename electrode table column names for spyglass

### DIFF
--- a/src/jdb_to_nwb/convert_raw_ephys.py
+++ b/src/jdb_to_nwb/convert_raw_ephys.py
@@ -742,7 +742,7 @@ def add_electrode_data_berke_probe(
         description="The Open Ephys channel name (1-based) for the electrode",
     )
     nwbfile.add_electrode_column(
-        name="channel_name",
+        name="imp_file_channel_name",
         description="The name of the channel from the impedance file",
     )
     nwbfile.add_electrode_column(
@@ -750,7 +750,7 @@ def add_electrode_data_berke_probe(
         description="The port of the electrode from the impedance file",
     )
     nwbfile.add_electrode_column(
-        name="impedance",
+        name="imp",
         description="The impedance of the electrode (Impedance Magnitude at 1000 Hz (ohms))",
     )
     nwbfile.add_electrode_column(
@@ -845,9 +845,9 @@ def add_electrode_data_berke_probe(
                 electrode_name=row["electrode_name"],
                 intan_channel_number=row["intan_channel"],
                 open_ephys_channel_str=row["open_ephys_channel_string"],
-                channel_name=row["Channel Name"],
+                imp_file_channel_name=row["Channel Name"],
                 port=row["Port"],
-                impedance=row["Impedance Magnitude at 1000 Hz (ohms)"],
+                imp=row["Impedance Magnitude at 1000 Hz (ohms)"],
                 imp_phase=row["Impedance Phase at 1000 Hz (degrees)"],
                 series_resistance_in_ohms=row["Series RC equivalent R (Ohms)"],
                 series_capacitance_in_farads=row["Series RC equivalent C (Farads)"],

--- a/tests/test_convert_raw_ephys.py
+++ b/tests/test_convert_raw_ephys.py
@@ -169,12 +169,12 @@ def test_add_electrode_data_berke_probe(dummy_logger):
     # Strip any suffix like "/SCREW#" from actual electrode names
     electrode_names = [name.split('/')[0] for name in nwbfile.electrodes.electrode_name.data[:]]
     assert electrode_names == expected_electrode_names
-    assert nwbfile.electrodes.channel_name.data[:] == expected_channel_names
+    assert nwbfile.electrodes.imp_file_channel_name.data[:] == expected_channel_names
     assert nwbfile.electrodes.port.data[:] == expected_port_labels
     assert (nwbfile.electrodes.intan_channel_number.data[:] == expected_intan_channel_numbers).all()
 
     # Check first electrode data (S01E1)
-    assert nwbfile.electrodes.impedance.data[0] == 6.50e06
+    assert nwbfile.electrodes.imp.data[0] == 6.50e06
     assert nwbfile.electrodes.imp_phase.data[0] == -68
     assert nwbfile.electrodes.series_resistance_in_ohms.data[0] == 2.44e06
     assert nwbfile.electrodes.series_capacitance_in_farads.data[0] == 2.64e-11
@@ -183,7 +183,7 @@ def test_add_electrode_data_berke_probe(dummy_logger):
     assert nwbfile.electrodes.rel_y.data[0] == 255.0
 
     # Check last electrode data (S32E8)
-    assert nwbfile.electrodes.impedance.data[-1] == 2.24e06
+    assert nwbfile.electrodes.imp.data[-1] == 2.24e06
     assert nwbfile.electrodes.imp_phase.data[-1] == -43
     assert nwbfile.electrodes.series_resistance_in_ohms.data[-1] == 1.63e06
     assert nwbfile.electrodes.series_capacitance_in_farads.data[-1] == 1.04e-10


### PR DESCRIPTION
Resolves #171 and #161 so we can more easily move forward with spyglass.

These will likely (hopefully) be resolved on the spyglass end eventually, but this works well for now
