### PR TITLE
Hotfix: Fix broadcasting error when writing ephys data to nwbfile

### DIFF
--- a/src/jdb_to_nwb/convert_raw_ephys.py
+++ b/src/jdb_to_nwb/convert_raw_ephys.py
@@ -21,7 +21,6 @@ from neuroconv.tools.spikeinterface.spikeinterfacerecordingdatachunkiterator imp
 )
 from pynwb import NWBFile
 from pynwb.ecephys import ElectricalSeries
-from hdmf.data_utils import DataChunkIterator
 from spikeinterface.extractors import OpenEphysBinaryRecordingExtractor
 
 from .utils import get_logger_directory


### PR DESCRIPTION
Fix #180 

Ah yes, the simple fix. Just create a `MicrovoltsSpikeInterfaceRecordingDataChunkIterator`. Of course.