### PR TITLE
Save conversion logs, metadata, and electrode info as associatedfiles objects

### DIFF
--- a/src/jdb_to_nwb/convert.py
+++ b/src/jdb_to_nwb/convert.py
@@ -7,6 +7,7 @@ import shutil
 
 from pynwb import NWBFile, NWBHDF5IO
 from pynwb.file import Subject
+from ndx_franklab_novela import AssociatedFiles
 
 from . import __version__
 from .utils import to_datetime, setup_logger
@@ -193,6 +194,31 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
 
     # Set the timestamps reference time equal to the session start time
     nwbfile.fields["timestamps_reference_time"] = nwbfile.fields["session_start_time"]
+
+    # Flush log handlers so all messages are on disk before we read them into the NWB
+    for handler in logger.handlers:
+        handler.flush()
+
+    # Save metadata YAML and log files as AssociatedFiles objects in the NWB so the NWB is self-contained
+    if "associated_files" not in nwbfile.processing:
+        nwbfile.create_processing_module(name="associated_files", description="Contains all associated files")
+
+    files_to_embed = [
+        ("metadata_yaml",  "Metadata YAML file used to create this NWB file", metadata_copy_file_path),
+        ("info_log",       "Info-level conversion log",                         info_log_file),
+        ("warning_log",    "Warning-level conversion log",                      warning_log_file),
+        ("debug_log",      "Debug-level conversion log",                        debug_log_file),
+    ]
+    for name, description, file_path in files_to_embed:
+        with open(file_path, "r") as f:
+            content = f.read()
+        nwbfile.processing["associated_files"].add(AssociatedFiles(
+            name=name,
+            description=description,
+            content=content,
+            task_epochs="0",
+        ))
+        logger.info(f"Saved {file_path.name} as AssociatedFiles object '{name}' in NWB")
 
     print("Writing file...")
     logger.info("Writing file...")

--- a/src/jdb_to_nwb/convert_raw_ephys.py
+++ b/src/jdb_to_nwb/convert_raw_ephys.py
@@ -836,6 +836,18 @@ def add_electrode_data_berke_probe(
     # Get dataframe of electrode information (channel map, x/y coordinates, and impedance info)
     electrode_info = get_electrode_info(metadata=metadata, logger=logger, fig_dir=fig_dir)
 
+    # Save electrode info as an AssociatedFiles object in the NWB
+    if "associated_files" not in nwbfile.processing:
+        logger.debug("Creating nwb processing module for associated files")
+        nwbfile.create_processing_module(name="associated_files", description="Contains all associated files")
+    logger.debug("Saving electrode info CSV as an AssociatedFiles object")
+    nwbfile.processing["associated_files"].add(AssociatedFiles(
+        name="electrode_info",
+        description="Electrode channel map and impedance information (CSV)",
+        content=electrode_info.to_csv(index=False),
+        task_epochs="0",
+    ))
+
     # Get general metadata for the Probe
     electrodes_location = metadata["ephys"].get("electrodes_location", "unspecified")
     if electrodes_location == "unspecified":


### PR DESCRIPTION
Resolves #187 

Confirmed the metadata and warning/debug/info log files are saved correctly as `AssociatedFiles` when I ran a conversion. I am able to access the text of each of these from the converted nwb. 

Note that the content of the files saved in the nwb cuts off at the time the files are written to the nwb (e.g. the last line in the saved `info_log` object will be: 

```
11-May-26 20:25:53 [INFO] Saved IM-1478_20220725_metadata.yaml as AssociatedFiles object 'metadata_yaml' in NWB
``` 

and it won't include the final lines:
```
11-May-26 20:25:53 [INFO] Saved IM-1478_20220725_info_logs.log as AssociatedFiles object 'info_log' in NWB
11-May-26 20:25:53 [INFO] Saved IM-1478_20220725_warning_logs.log as AssociatedFiles object 'warning_log' in NWB
11-May-26 20:25:53 [INFO] Saved IM-1478_20220725_debug_logs.log as AssociatedFiles object 'debug_log' in NWB
11-May-26 20:25:53 [INFO] Writing file...
11-May-26 20:25:56 [INFO] NWB file created successfully at test0511/IM-1478_20220725.nwb
```

that happen after the file is written. This isn't really an issue, but sadly means we miss saving the timestamps of how long it took to actually write the file. So be it.