### PR TITLE
Fix issues with ffmpeg not being found

### DIFF
--- a/src/jdb_to_nwb/convert_video.py
+++ b/src/jdb_to_nwb/convert_video.py
@@ -134,10 +134,21 @@ def compress_avi_to_mp4(input_video_path, output_video_path, logger, crf=23, pre
     preset (str): ffmpeg compression speed preset: \
         "ultrafast", "superfast", "fast", "medium", "slow", "slower", "veryslow"
     """
+    # Prefer the ffmpeg binary bundled with imageio-ffmpeg (portable, no system install needed).
+    # Fall back to system ffmpeg if imageio-ffmpeg is not installed.
+    try:
+        import imageio_ffmpeg
+        ffmpeg_exe = imageio_ffmpeg.get_ffmpeg_exe()
+        logger.debug(f"Using ffmpeg binary from imageio-ffmpeg: {ffmpeg_exe}")
+    except ImportError:
+        ffmpeg_exe = "ffmpeg"
+        logger.debug("imageio-ffmpeg not installed, falling back to system ffmpeg")
+
+    logger.debug(f"Compression settings: crf={crf}, preset={preset}")
     try:
         (
             ffmpeg.input(str(input_video_path)).output(str(output_video_path), vcodec="libx264", crf=crf, preset=preset)
-            .run(overwrite_output=True, capture_stdout=False, capture_stderr=True)
+            .run(cmd=ffmpeg_exe, overwrite_output=True, capture_stdout=False, capture_stderr=True)
         )
         logger.info(f"Compressed video at {input_video_path} to {output_video_path}")
         print(f"Compressed video at {input_video_path} to {output_video_path}")

--- a/src/jdb_to_nwb/convert_video.py
+++ b/src/jdb_to_nwb/convert_video.py
@@ -1,5 +1,6 @@
 import os
 import csv
+import shutil
 import ffmpeg
 import numpy as np
 import pandas as pd
@@ -136,15 +137,27 @@ def compress_avi_to_mp4(input_video_path, output_video_path, logger, crf=23, pre
     """
     # Prefer the ffmpeg binary bundled with imageio-ffmpeg (portable, no system install needed).
     # Fall back to system ffmpeg if imageio-ffmpeg is not installed.
+    # We have all of these options because ffmpeg wasn't being found on different systems 
+    # (see Github issues #147 and #188)
     try:
+        # Try bundled ffmpeg binary, works without a system ffmpeg install
         import imageio_ffmpeg
         ffmpeg_exe = imageio_ffmpeg.get_ffmpeg_exe()
         logger.debug(f"Using ffmpeg binary from imageio-ffmpeg: {ffmpeg_exe}")
     except ImportError:
-        ffmpeg_exe = "ffmpeg"
-        logger.debug("imageio-ffmpeg not installed, falling back to system ffmpeg")
+        # If that didn't work, check for ffmpeg on PATH
+        ffmpeg_exe = shutil.which("ffmpeg")
+        logger.debug(f"imageio-ffmpeg not installed, falling back to system ffmpeg: {ffmpeg_exe}")
 
-    logger.debug(f"Compression settings: crf={crf}, preset={preset}")
+    if ffmpeg_exe is None:
+        # Neither imageio-ffmpeg nor system ffmpeg (PATH) is available :(
+        # This shouldn't happen if you ran an up-to-date `pip install -e .` !!!
+        logger.error("FFmpeg not found! Run `pip install -e .` to install imageio-ffmpeg")
+        raise RuntimeError(
+            "FFmpeg not found! Run `pip install -e .` to install imageio-ffmpeg or add ffmpeg to your system PATH"
+            )
+
+    logger.debug(f"Using video compression settings: crf={crf}, preset={preset}")
     try:
         (
             ffmpeg.input(str(input_video_path)).output(str(output_video_path), vcodec="libx264", crf=crf, preset=preset)


### PR DESCRIPTION
Resolves #147 and resolves #188

Video compression failed in environments without a system ffmpeg install with `[WinError 2] The system cannot find the file specified` (on Windows, see #147) or `[Errno 2] No such file or directory: 'ffmpeg'` (on MacOS/Linux, see #188). 

This happened because `ffmpeg-python` (the Python API we use to build ffmpeg commands) does not bundle ffmpeg and relies on an external ffmpeg binary (which it looks for in the system PATH, but wasn't finding). `imageio-ffmpeg` (which bundles ffmpeg) is included as a dependency, but the previous implementation did not explicitly use its bundled binary path. So we kept getting ffmpeg not found.

At compression time, we now explicitly resolve the ffmpeg binary using:
1. `imageio_ffmpeg.get_ffmpeg_exe()` to get the bundled binary path. (Pretty sure this should always work if you're using an up-to-date env with all dependencies)
2. If it somehow doesn't work, use `shutil.which("ffmpeg")` as a fallback to check for ffmpeg on the system PATH, and use that one.

If neither works, raise an error and tell the user to run `pip install -e .` which should fix it ibecause `imageio-ffmpeg` is declared as a dependency (so this is basically running `pip install imageio-ffmpeg`, among other installs)

