### PR TITLE
Allow pipeline to align timestamps even when photometry crashes and ends before behavior

### DIFF
--- a/src/jdb_to_nwb/convert_behavior.py
+++ b/src/jdb_to_nwb/convert_behavior.py
@@ -301,15 +301,11 @@ def align_data_to_visits(trial_data, block_data, metadata, logger):
     elif len(trial_data) > len(ground_truth_visit_times):
         arduino_visits = [trial['beam_break_start'] for trial in trial_data]
         n_extra = len(trial_data) - len(ground_truth_visit_times)
-        # Log it at CRITICAL and complain a lot so the user knows something is wrong!
         logger.critical(
             f"Found {n_extra} more trial(s) recorded by arduino ({len(trial_data)}) than "
             f"ground truth {ground_truth_time_source} visits ({len(ground_truth_visit_times)}). "
         )
         logger.critical(f"This should not happen and likely means that {ground_truth_time_source} crashed!!")
-        logger.critical("Attempting alignment by building interpolation function from "
-                       f"{len(ground_truth_visit_times)} matched {ground_truth_time_source} visits "
-                       f"and applying to all {len(trial_data)} trials (unmatched trial(s) will be extrapolated).")
 
         # Find the subset of arduino visit times that have corresponding ground truth pulses
         # by trimming to the length of ground_truth_visit_times
@@ -345,7 +341,7 @@ def align_data_to_visits(trial_data, block_data, metadata, logger):
                 )
             # Log each unmatched visit time + extrapolated counterpart at the start of the session
             for v, t in unmatched_before:
-                logger.debug(f"Prepending extrapolated ground truth visit time {t:.4f}s "
+                logger.debug(f"Prepending extrapolated `ground truth` visit time {t:.4f}s "
                                f"(arduino time {v:.4f}s) to the start of ground_truth_visit_times")
         # If unmatched after, log that we ended phot/ephys early
         for v, t in unmatched_after:
@@ -354,7 +350,7 @@ def align_data_to_visits(trial_data, block_data, metadata, logger):
                 f"This suggests {ground_truth_time_source} ended early. Check DEBUG log for extrapolated alignment."
                 )
             # Log each unmatched visit time + extrapolated counterpart at the end of the session
-            logger.debug(f"Appending extrapolated ground truth visit time {t:.4f}s "
+            logger.debug(f"Appending extrapolated `ground truth` visit time {t:.4f}s "
                            f"(arduino time {v:.4f}s) to the end of ground_truth_visit_times")
 
         # Add our extrapolated "ground truth" times so we can continue with alignment as normal

--- a/src/jdb_to_nwb/convert_behavior.py
+++ b/src/jdb_to_nwb/convert_behavior.py
@@ -335,12 +335,42 @@ def align_data_to_visits(trial_data, block_data, metadata, logger):
             logger.warning(f"Extrapolated `ground truth` visit time {fake_gt_time:.4f}s "
                            f"for unmatched arduino visit at {unmatched_arduino_time:.4f}s")
 
-        # Insert extrapolated time(s) into ground_truth_visit_times at the correct positions,
-        # keeping all existing ground truth visit times unchanged
-        ground_truth_visit_times = list(ground_truth_visit_times)
-        for i, (arduino_time, gt_time) in enumerate(zip(arduino_unmatched, extrapolated_gt_times)):
-            insert_idx = i + sum(1 for v in arduino_matched if v < arduino_time)
-            ground_truth_visit_times.insert(insert_idx, float(gt_time))
+        # Unmatched visits are always at the start or end (if we missed a pulse in the middle we have 
+        # bigger problems!! but this has never happened), so prepend/append extrapolated times accordingly.
+        # We expect unmatched visits to all be at the END (meaning phot/ephys crashed before behavior ended).
+        # Complain if any are at the start (that would mean we are confused or phot/ephys was started late instead).
+        unmatched_before = [(v, t) for v, t in zip(arduino_unmatched, extrapolated_gt_times) if v < arduino_matched[0]]
+        unmatched_after  = [(v, t) for v, t in zip(arduino_unmatched, extrapolated_gt_times) if v > arduino_matched[-1]]
+        # If unmatched before, log that we started phot/ephys late
+        if unmatched_before:
+            logger.critical(
+                f"Found {len(unmatched_before)} unmatched arduino visit(s) at the START of the session! "
+                f"This suggests {ground_truth_time_source} started late (bad!!), not that it crashed early."
+                )
+            logger.critical(
+                "This is unexpected. Confirm this matches known experimental setup "
+                "and carefully check DEBUG logs to confirm alignment is ok."
+                )
+            # Log each unmatched visit time + extrapolated counterpart at the start of the session
+            for v, t in unmatched_before:
+                logger.debug(f"Prepending extrapolated ground truth visit time {t:.4f}s "
+                               f"(arduino time {v:.4f}s) to the start of ground_truth_visit_times")
+        # If unmatched after, log that we ended phot/ephys early
+        for v, t in unmatched_after:
+            logger.warning(
+                f"Found {len(unmatched_after)} unmatched arduino visit(s) at the end of the session! "
+                f"This suggests {ground_truth_time_source} ended early. Check DEBUG log for extrapolated alignment."
+                )
+            # Log each unmatched visit time + extrapolated counterpart at the end of the session
+            logger.debug(f"Appending extrapolated ground truth visit time {t:.4f}s "
+                           f"(arduino time {v:.4f}s) to the end of ground_truth_visit_times")
+
+        # Add our extrapolated "ground truth" times so we can continue with alignment as normal
+        ground_truth_visit_times = (
+            [t for _, t in unmatched_before] 
+            + list(ground_truth_visit_times) 
+            + [t for _, t in unmatched_after]
+        )
 
     # Now that we have the correct number of ground truth visit times, replace arduino times with ground truth times
     for trial, visit_time in zip(trial_data, ground_truth_visit_times):

--- a/src/jdb_to_nwb/convert_behavior.py
+++ b/src/jdb_to_nwb/convert_behavior.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from pynwb import NWBFile
 from hdmf.common.table import DynamicTable, VectorData
 from ndx_franklab_novela import AssociatedFiles
-from .timestamps_alignment import trim_sync_pulses, handle_timestamps_reset
+from .timestamps_alignment import trim_sync_pulses, align_via_interpolation, handle_timestamps_reset
 from .plotting.plot_behavior import plot_maze_configurations, plot_trial_time_histogram
 
 
@@ -296,12 +296,32 @@ def align_data_to_visits(trial_data, block_data, metadata, logger):
         ground_truth_visit_times, arduino_visits = trim_sync_pulses(ground_truth_visit_times, arduino_visits, logger)
 
     # We should never have more trials than photometry/ephys visits.
-    # If we do, error so we can figure out why this happened and handle it accordingly.
+    # If we do, it likely means photometry/ephys crashed while behavior was still running (see Github issue #194)
+    # This is not ideal for alignment but we will try our best. 
     elif len(trial_data) > len(ground_truth_visit_times):
-        logger.critical(f"Found more trials recorded by arduino ({len(trial_data)}) "
-                        f"than {ground_truth_time_source} visits ({len(ground_truth_visit_times)})!!!")
-        logger.critical("This should never happen!!! Skipping alignment of trial/block data.")
-        return trial_data, block_data
+        arduino_visits = [trial['beam_break_start'] for trial in trial_data]
+        n_extra = len(trial_data) - len(ground_truth_visit_times)
+        # Log it at CRITICAL and complain a lot so the user knows something is wrong!
+        logger.critical(
+            f"Found {n_extra} more trial(s) recorded by arduino ({len(trial_data)}) than "
+            f"ground truth {ground_truth_time_source} visits ({len(ground_truth_visit_times)}). "
+        )
+        logger.critical(f"This should not happen and likely means that {ground_truth_time_source} crashed!!")
+        logger.critical("Attempting alignment by building interpolation function from "
+                       f"{len(ground_truth_visit_times)} matched {ground_truth_time_source} visits "
+                       f"and applying to all {len(trial_data)} trials (unmatched trial(s) will be extrapolated).")
+        logger.critical("Carefully check DEBUG conversion log and all created figures to make sure alignment is ok.")
+        
+        # TODO: create extra "ground truth" visit time(s) via extrapolation
+        # so we have the same number of visit times and ground truth visit times
+        # this gets risky the more we are extrapolating, so log everything.
+        # make sure we don't mess with any of the exisiting ground truth visit times
+        ground_truth_visit_times = align_via_interpolation(
+            unaligned_timestamps=arduino_visits,
+            unaligned_visit_times=arduino_visits,
+            ground_truth_visit_times=ground_truth_visit_times,
+            logger=logger,
+        )
 
     # Now that we have the correct number of ground truth visit times, replace arduino times with ground truth times
     for trial, visit_time in zip(trial_data, ground_truth_visit_times):

--- a/src/jdb_to_nwb/convert_behavior.py
+++ b/src/jdb_to_nwb/convert_behavior.py
@@ -310,8 +310,7 @@ def align_data_to_visits(trial_data, block_data, metadata, logger):
         logger.critical("Attempting alignment by building interpolation function from "
                        f"{len(ground_truth_visit_times)} matched {ground_truth_time_source} visits "
                        f"and applying to all {len(trial_data)} trials (unmatched trial(s) will be extrapolated).")
-        logger.critical("Carefully check DEBUG conversion log and all created figures to make sure alignment is ok.")
-        
+
         # Find the subset of arduino visit times that have corresponding ground truth pulses
         # by trimming to the length of ground_truth_visit_times
         _, arduino_matched = trim_sync_pulses(ground_truth_visit_times, arduino_visits, logger)
@@ -330,10 +329,6 @@ def align_data_to_visits(trial_data, block_data, metadata, logger):
             ground_truth_visit_times=ground_truth_visit_times,
             logger=logger,
         )
-        # Log extrapolated "ground truth" visits at WARNING level bc this is a little sketchy
-        for unmatched_arduino_time, fake_gt_time in zip(arduino_unmatched, extrapolated_gt_times):
-            logger.warning(f"Extrapolated `ground truth` visit time {fake_gt_time:.4f}s "
-                           f"for unmatched arduino visit at {unmatched_arduino_time:.4f}s")
 
         # Unmatched visits are always at the start or end (if we missed a pulse in the middle we have 
         # bigger problems!! but this has never happened), so prepend/append extrapolated times accordingly.
@@ -346,10 +341,7 @@ def align_data_to_visits(trial_data, block_data, metadata, logger):
             logger.critical(
                 f"Found {len(unmatched_before)} unmatched arduino visit(s) at the START of the session! "
                 f"This suggests {ground_truth_time_source} started late (bad!!), not that it crashed early."
-                )
-            logger.critical(
-                "This is unexpected. Confirm this matches known experimental setup "
-                "and carefully check DEBUG logs to confirm alignment is ok."
+                "Confirm this matches known experimental setup and check DEBUG logs to confirm alignment is ok."
                 )
             # Log each unmatched visit time + extrapolated counterpart at the start of the session
             for v, t in unmatched_before:

--- a/src/jdb_to_nwb/convert_behavior.py
+++ b/src/jdb_to_nwb/convert_behavior.py
@@ -312,16 +312,35 @@ def align_data_to_visits(trial_data, block_data, metadata, logger):
                        f"and applying to all {len(trial_data)} trials (unmatched trial(s) will be extrapolated).")
         logger.critical("Carefully check DEBUG conversion log and all created figures to make sure alignment is ok.")
         
-        # TODO: create extra "ground truth" visit time(s) via extrapolation
-        # so we have the same number of visit times and ground truth visit times
-        # this gets risky the more we are extrapolating, so log everything.
-        # make sure we don't mess with any of the exisiting ground truth visit times
-        ground_truth_visit_times = align_via_interpolation(
-            unaligned_timestamps=arduino_visits,
-            unaligned_visit_times=arduino_visits,
+        # Find the subset of arduino visit times that have corresponding ground truth pulses
+        # by trimming to the length of ground_truth_visit_times
+        _, arduino_matched = trim_sync_pulses(ground_truth_visit_times, arduino_visits, logger)
+
+        # Find arduino visit times without corresponding ground truth sync pulses from photometry/ephys
+        arduino_unmatched = [v for v in arduino_visits if v not in set(arduino_matched.tolist())]
+
+        # Extrapolate "ground truth" visit time(s) for unmatched arduino visit(s),
+        # using arduino_matched and ground_truth_visit_times to build the interpolation function
+        logger.debug(
+            "Building extrapolation function between matched arduino visit times and ground truth visit times "
+            "so we can create `ground truth` times for umatched arduino visits.")
+        extrapolated_gt_times = align_via_interpolation(
+            unaligned_timestamps=arduino_unmatched,
+            unaligned_visit_times=arduino_matched,
             ground_truth_visit_times=ground_truth_visit_times,
             logger=logger,
         )
+        # Log extrapolated "ground truth" visits at WARNING level bc this is a little sketchy
+        for unmatched_arduino_time, fake_gt_time in zip(arduino_unmatched, extrapolated_gt_times):
+            logger.warning(f"Extrapolated `ground truth` visit time {fake_gt_time:.4f}s "
+                           f"for unmatched arduino visit at {unmatched_arduino_time:.4f}s")
+
+        # Insert extrapolated time(s) into ground_truth_visit_times at the correct positions,
+        # keeping all existing ground truth visit times unchanged
+        ground_truth_visit_times = list(ground_truth_visit_times)
+        for i, (arduino_time, gt_time) in enumerate(zip(arduino_unmatched, extrapolated_gt_times)):
+            insert_idx = i + sum(1 for v in arduino_matched if v < arduino_time)
+            ground_truth_visit_times.insert(insert_idx, float(gt_time))
 
     # Now that we have the correct number of ground truth visit times, replace arduino times with ground truth times
     for trial, visit_time in zip(trial_data, ground_truth_visit_times):

--- a/src/jdb_to_nwb/plotting/plot_combined.py
+++ b/src/jdb_to_nwb/plotting/plot_combined.py
@@ -33,14 +33,17 @@ def plot_photometry_signal_aligned_to_port_entry(nwbfile, signal_name, fig_dir=N
     # Split by rewarded vs unrewarded trials
     rewarded, un_rewarded = [], []
 
+    # Get trace centered on poke_in
     for poke_in, reward in zip(poke_in_times, rewards):
 
-        # Extract signal trace centered on poke_in
-        idx = np.where(timestamps == poke_in)[0][0]
+        # Find the photometry sample closest to poke_in (nearest-sample rather than exact equality,
+        # because extrapolated visit times may not exactly match a photometry sample timestamp)
+        idx = np.argmin(np.abs(timestamps - poke_in))
         start_idx = max(0, idx - num_samples // 2)
         end_idx = start_idx + num_samples
 
-        if end_idx <= len(signal_trace):  # Ensure within bounds
+        # Exclude this trial from the average if we don't have photometry signal within bounds
+        if end_idx <= len(signal_trace):
             trace = signal_trace[start_idx:end_idx]
             (rewarded if reward == 1 else un_rewarded).append(trace)
 


### PR DESCRIPTION
Resolves #194 

Looks like it's finally time to update my previous comment:

https://github.com/calderast/jdb_to_nwb/blob/142d64dc763d5ea908964d8d83e3410e491a11c1/src/jdb_to_nwb/convert_behavior.py#L298-L299

The error was very descriptive and helpful, thank you past Stephanie. It happened because photometry crashed. And I have decided that "handle it accordingly" means try our best to align the extra arduino visits via extrapolation:

We first build a linear interpolation function between the arduino visits and our matched ground truth (photometry) visits. We then use this to extrapolate "ground truth" time(s) for the unmatched arduino visit(s). Yes, I realize that they are no longer ground truth because they are artificially created via extrapolation. They are effectively our best guess of what the umatched arduino visits would be in photometry time, based on the relationship between the matched arduino visits and photometry visits we do have. The extrapolated "ground truth" times are appended to ground_truth_visit_times so alignment can proceed normally for all trials. 

I also add a TON of logging (at `CRITICAL`, because we don't ever expect this to happen unless something went wrong).  We warn extra if the unmatched arduino visits appear at the start of the session rather than the end, because this would mean that our ground truth (photometry/ephys) was started late vs crashed early. 