### PR TITLE
Allow user to specify custom barrier shift trials that differ from arduino

### DIFF
--- a/metadata_fully_explained.yaml
+++ b/metadata_fully_explained.yaml
@@ -173,6 +173,16 @@ behavior:
   # For probability change sessions, this can be a single line that will be used for all blocks.
   # Any lines starting with `#` in the file will be ignored, so feel free to add comments as well.
   maze_configuration_file_path: "path/to/barriers.txt"
+  
+  # OPTIONAL - If the barriers were switched at a different trial than the arduino printout, use this field to
+  # specify the actual number of trials in each block. The values must sum to the total number of trials in the 
+  # session. For example, if the arduino output has 3 blocks with 68/66/54 trials, but the first barrier switch 
+  # happened one trial late, specify [69, 65, 54]. 
+  # The number of mazes in the maze configuration file (barriers.txt) must match the number of blocks here.
+  # For example, if arduino recorded 68/66/67/2 (e.g. you didn't stop the recording in time, but didn't shift 
+  # the barrier at the end), you could specify 68/66/69 and the 3 mazes you actually used to end up with 3 blocks.
+  # This field will be ignored for probability change sessions.
+  barrier_switch_trial_counts: [69, 65, 54]
 
 video:
   # The video and video timestamps files are auto-generated while running the task

--- a/metadata_fully_explained.yaml
+++ b/metadata_fully_explained.yaml
@@ -174,15 +174,15 @@ behavior:
   # Any lines starting with `#` in the file will be ignored, so feel free to add comments as well.
   maze_configuration_file_path: "path/to/barriers.txt"
   
-  # OPTIONAL - If the barriers were switched at a different trial than the arduino printout, use this field to
+  # OPTIONAL - If the barriers were shifted at a different trial than the arduino printout, use this field to
   # specify the actual number of trials in each block. The values must sum to the total number of trials in the 
-  # session. For example, if the arduino output has 3 blocks with 68/66/54 trials, but the first barrier switch 
+  # session. For example, if the arduino output has 3 blocks with 68/66/54 trials, but the first barrier shift 
   # happened one trial late, specify [69, 65, 54]. 
   # The number of mazes in the maze configuration file (barriers.txt) must match the number of blocks here.
   # For example, if arduino recorded 68/66/67/2 (e.g. you didn't stop the recording in time, but didn't shift 
   # the barrier at the end), you could specify 68/66/69 and the 3 mazes you actually used to end up with 3 blocks.
   # This field will be ignored for probability change sessions.
-  barrier_switch_trial_counts: [69, 65, 54]
+  barrier_shift_trial_counts: [69, 65, 54]
 
 video:
   # The video and video timestamps files are auto-generated while running the task

--- a/src/jdb_to_nwb/convert_behavior.py
+++ b/src/jdb_to_nwb/convert_behavior.py
@@ -658,8 +658,10 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
     
     # We sometimes move the barriers at a different time than the trial indicated by the arduino output
     # (to avoid moving a barrier right next to the rat, etc.). 
-    # If so, "barrier_switch_trial_counts" in metadata specifies the actual number of trials in each block
-    user_block_trial_counts = metadata.get("behavior", {}).get("barrier_switch_trial_counts")
+    # If so, "barrier_shift_trial_counts" in metadata specifies the actual number of trials in each block
+    user_block_trial_counts = metadata.get("behavior", {}).get("barrier_shift_trial_counts")
+    if user_block_trial_counts is not None:
+        logger.info(f"Detected user-specified `barrier_shift_trial_counts`: {user_block_trial_counts}")
 
     # Validate maze configurations based on session type
     if session_type == "probability change":
@@ -681,7 +683,7 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
             )
     else:
         # If this is a barrier change session, we must have one maze per arduino block,
-        # or one maze per user-specified block (if barrier_switch_trial_counts is set)
+        # or one maze per user-specified block (if barrier_shift_trial_counts is set)
         n_expected = len(user_block_trial_counts) if user_block_trial_counts is not None else len(block_data)
         if len(maze_configurations) != n_expected:
             logger.error(
@@ -699,27 +701,27 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
     # Align visit times to photometry/ephys
     trial_data, block_data = align_data_to_visits(trial_data, block_data, metadata, logger)
 
-    # Re-assign block boundaries accordingly if the user specified "barrier_switch_trial_counts" in metadata
+    # Re-assign block boundaries accordingly if the user specified "barrier_shift_trial_counts" in metadata
     # e.g. arduino output = 66/63/67/61 trials per block, user specifies [67, 62, 68, 60], so we update things
     # so blocks switch after trials [67, 129, 197] instead of [66, 129, 196]
     if user_block_trial_counts is not None:
         if session_type != "barrier change":
             logger.warning(
-                "'barrier_switch_trial_counts' is set in metadata but this is not a barrier change session!"
+                "'barrier_shift_trial_counts' is set in metadata but this is not a barrier change session!"
                 )
             logger.warning(
-                "Information in 'barrier_switch_trial_counts' will be ignored. This should only be set in barrier"
-                "change sessions when the true barrier switch trials do not match the printed arduino output."
+                "Information in 'barrier_shift_trial_counts' will be ignored. This should only be set in barrier"
+                "change sessions when the true barrier shift trials do not match the printed arduino output."
                 )
         else:
             # The total number of user-specified trials must sum to the number of trials recorded by arduino
             if sum(user_block_trial_counts) != len(trial_data):
                 logger.error(
-                    f"barrier_switch_trial_counts {user_block_trial_counts} sums to {sum(user_block_trial_counts)} "
+                    f"barrier_shift_trial_counts {user_block_trial_counts} sums to {sum(user_block_trial_counts)} "
                     f"trials, but there are {len(trial_data)} total trials recorded by arduino!"
                     )
                 raise ValueError(
-                    f"barrier_switch_trial_counts {user_block_trial_counts} sums to {sum(user_block_trial_counts)} "
+                    f"barrier_shift_trial_counts {user_block_trial_counts} sums to {sum(user_block_trial_counts)} "
                     f"trials, but there are {len(trial_data)} total trials recorded by arduino!"
                     )
             else:

--- a/src/jdb_to_nwb/convert_behavior.py
+++ b/src/jdb_to_nwb/convert_behavior.py
@@ -548,49 +548,56 @@ def validate_trial_and_block_data(trial_data: list, block_data: list, logger):
     logger.debug(f"The number of trials in each block sums to the total number of trials {len(trial_data)}")
 
 
-def reassign_block_boundaries(trial_data, block_data, switch_after_trials, logger):
+def reassign_block_boundaries(trial_data, block_data, switch_after_trials, maze_configurations, logger):
     """
-    Re-assign which trials belong to which block based on user-specified switch trial numbers.
-    Used when the arduino's block detection doesn't match when barriers were actually switched.
+    Re-assign which trials belong to which block based on user-specified barrier switch trial numbers.
+
+    The number of user-specified blocks (len(switch_after_trials) + 1) may differ from the number of
+    arduino-detected blocks. maze_configurations must have one entry per user-specified block.
 
     Args:
     switch_after_trials (list[int]): Trial numbers after which the block switched.
         For N blocks, there should be N-1 entries.
-        e.g. [42, 85] means block 1 = trials 1-42, block 2 = trials 43-85, block 3 = trials 86+
+        e.g. [66, 61] means block 1 is trials 1-66, block 2 is trials 67-127, block 3 is trials 128+
+    maze_configurations (list[str]): Maze configuration string for each user-specified block, in order.
     """
-    n_blocks = len(block_data)
-    if len(switch_after_trials) != n_blocks - 1:
-        logger.error(f"Expected {n_blocks - 1} switch point(s) for {n_blocks} blocks, "
-                     f"got {len(switch_after_trials)}: {switch_after_trials}")
-        raise ValueError(f"Expected {n_blocks - 1} switch point(s) for {n_blocks} blocks, "
-                         f"got {len(switch_after_trials)}")
-
-    logger.info(f"Reassigning block boundaries based on user-specified switch times: "
+    n_new_blocks = len(switch_after_trials) + 1
+    logger.info("Reassigning block boundaries based on user-specified barrier shift times: "
                 f"blocks switch after trials {switch_after_trials}")
+    if n_new_blocks != len(block_data):
+        logger.warning(f"Number of blocks changing from {len(block_data)} (arduino) "
+                    f"to {n_new_blocks} (user-specified)")
 
     # Re-assign block and trial_within_block for each trial
     # trial_data is ordered by trial_within_session, so we can slice directly
     boundaries = [0] + list(switch_after_trials) + [len(trial_data)]
-    for block_idx, (start, end) in enumerate(zip(boundaries, boundaries[1:])):
-        block_num = block_idx + 1
+    for block_num, (start, end) in enumerate(zip(boundaries, boundaries[1:]), start=1):
         for trial_within_block, trial in enumerate(trial_data[start:end], start=1):
             if trial['block'] != block_num:
-                logger.info(f"Reassigning trial {trial['trial_within_session']} "
+                logger.debug(f"Reassigning trial {trial['trial_within_session']} "
                             f"from block {trial['block']} to block {block_num}")
             trial['block'] = block_num
             trial['trial_within_block'] = trial_within_block
 
-    # Rebuild block start/end times and num_trials to match the new trial assignments
-    for block in block_data:
-        trials_in_block = [t for t in trial_data if t['block'] == block['block']]
-        block['num_trials'] = len(trials_in_block)
-        block['start_time'] = trials_in_block[0]['start_time']
-        block['end_time'] = trials_in_block[-1]['end_time']
-    # Block end time = start time of the next block (same convention as align_data_to_visits)
-    for block, next_block in zip(block_data, block_data[1:]):
-        block['end_time'] = next_block['start_time']
+    # Re-assign maze_configuration, num_trials, and start/end time for the updated block boundaries
+    # pA/pB/pC and task_type are the same for all blocks in a barrier change session.
+    new_block_data = []
+    for block_idx, (start, end) in enumerate(zip(boundaries, boundaries[1:])):
+        block_num = block_idx + 1
+        block_trials = trial_data[start:end]
+        new_block_data.append({
+            'block': block_num,
+            'pA': block_data[0]['pA'],
+            'pB': block_data[0]['pB'],
+            'pC': block_data[0]['pC'],
+            'task_type': block_data[0]['task_type'],
+            'maze_configuration': maze_configurations[block_idx],
+            'num_trials': len(block_trials),
+            'start_time': block_trials[0]['start_time'],
+            'end_time': block_trials[-1]['end_time'],
+        })
 
-    return trial_data, block_data
+    return trial_data, new_block_data
 
 
 def add_behavior(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
@@ -642,73 +649,94 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
     maze_configurations = load_maze_configurations(maze_configuration_file_path)
     logger.debug(f"Found {len(maze_configurations)} maze(s) in the maze configuration file")
 
-    # Make sure the number of blocks matches the number of loaded maze configurations
-    if len(block_data) != len(maze_configurations):
+    # Convert each maze config from a set to a sorted, comma separated string
+    # for compatibility with NWB and spyglass
+    def barrier_set_to_string(maze_set):
+        return ",".join(map(str, sorted(maze_set)))
+
+    maze_config_strings = [barrier_set_to_string(maze) for maze in maze_configurations]
+    
+    # We sometimes move the barriers at a different time than the trial indicated by the arduino output
+    # (to avoid moving a barrier right next to the rat, etc.). 
+    # If so, "barrier_switch_trial_counts" in metadata specifies the actual number of trials in each block
+    user_block_trial_counts = metadata.get("behavior", {}).get("barrier_switch_trial_counts")
+
+    # Validate maze configurations based on session type
+    if session_type == "probability change":
         # If this is a probability change session, we may have a single maze configuration
         # to be used for all blocks. If so, duplicate it so we have one maze per block.
-        if len(maze_configurations) == 1 and session_type == "probability change":
-            maze_configurations = maze_configurations * len(block_data)
-        else:
+        if len(maze_configurations) == 1:
+            maze_config_strings = maze_config_strings * len(block_data)
+        # Otherwise, the number of mazes in the file must match the number of blocks
+        elif len(maze_configurations) != len(block_data):
             logger.error(
-                f"There are {len(block_data)} blocks in the arduino text file, "
-                f"but {len(maze_configurations)} mazes in the maze configuration file. "
+                f"Probability change session has {len(block_data)} blocks but "
+                f"{len(maze_configurations)} mazes in the maze configuration file. "
+                "Expected 1 (shared across all blocks) or one per block."
             )
             raise ValueError(
-                f"There are {len(block_data)} blocks in the arduino text file, "
-                f"but {len(maze_configurations)} mazes in the maze configuration file. "
-                "There should be exactly one maze configuration per block, "
-                "or a single maze configuration if this is a probability change session."
+                f"Probability change session has {len(block_data)} blocks but "
+                f"{len(maze_configurations)} mazes in the maze configuration file. "
+                "Expected 1 (shared across all blocks) or one per block."
+            )
+    else:
+        # If this is a barrier change session, we must have one maze per arduino block,
+        # or one maze per user-specified block (if barrier_switch_trial_counts is set)
+        n_expected = len(user_block_trial_counts) if user_block_trial_counts is not None else len(block_data)
+        if len(maze_configurations) != n_expected:
+            logger.error(
+                f"There are {len(block_data)} blocks but {len(maze_configurations)} mazes "
+                f"in the maze configuration file (expected {n_expected})."
+            )
+            raise ValueError(
+                f"There are {len(block_data)} blocks but {len(maze_configurations)} mazes "
+                f"in the maze configuration file (expected {n_expected})."
             )
 
-    # Convert each maze config from a set to a sorted, comma separated string 
-    # for compatibility with NWB and spyglass
-    def barrier_set_to_string(set):
-        return ",".join(map(str, sorted(set)))
-
-    # Add the maze configuration to the metadata for each block
-    for i, (block, maze) in enumerate(zip(block_data, maze_configurations), start=1):
-        logger.debug(f"Block {i} maze: {barrier_set_to_string(maze)}")
-        block["maze_configuration"] = barrier_set_to_string(maze)
-
-    # Plot maze configurations for each block
-    plot_maze_configurations(block_data=block_data, fig_dir=fig_dir)
-
-    # Save original arduino visit times for alignment before we re-align to photometry/ephys  
+    # Save original arduino visit times for alignment before we re-align to photometry/ephys
     arduino_visit_times = [trial['beam_break_start'] for trial in trial_data]
 
     # Align visit times to photometry/ephys
     trial_data, block_data = align_data_to_visits(trial_data, block_data, metadata, logger)
 
-    # We sometimes move the barriers at a different time than the trial indicated by the arduino output
-    # (to avoid moving a barrier right next to the rat, etc.)
     # Re-assign block boundaries accordingly if the user specified "barrier_switch_trial_counts" in metadata
     # e.g. arduino output = 66/63/67/61 trials per block, user specifies [67, 62, 68, 60], so we update things
     # so blocks switch after trials [67, 129, 197] instead of [66, 129, 196]
-    if "barrier_switch_trial_counts" in metadata.get("behavior", {}):
+    if user_block_trial_counts is not None:
         if session_type != "barrier change":
-            logger.warning("'barrier_switch_trial_counts' is set in metadata but this is not a barrier change session!")
+            logger.warning(
+                "'barrier_switch_trial_counts' is set in metadata but this is not a barrier change session!"
+                )
             logger.warning(
                 "Information in 'barrier_switch_trial_counts' will be ignored. This should only be set in barrier"
                 "change sessions when the true barrier switch trials do not match the printed arduino output."
                 )
         else:
-            user_block_trial_counts = metadata["behavior"]["barrier_switch_trial_counts"]
-            # User must specify the number of trials in each block (e.g. something like [67, 62, 68, 60] for 4 blocks)
-            if len(user_block_trial_counts) != len(block_data):
-                logger.error(f"Expected {len(block_data)} values in 'barrier_switch_trial_counts' (one per block),"
-                             f"got {len(user_block_trial_counts)}: {user_block_trial_counts}")
             # The total number of user-specified trials must sum to the number of trials recorded by arduino
             if sum(user_block_trial_counts) != len(trial_data):
                 logger.error(
                     f"barrier_switch_trial_counts {user_block_trial_counts} sums to {sum(user_block_trial_counts)} "
                     f"trials, but there are {len(trial_data)} total trials recorded by arduino!"
                     )
+                raise ValueError(
+                    f"barrier_switch_trial_counts {user_block_trial_counts} sums to {sum(user_block_trial_counts)} "
+                    f"trials, but there are {len(trial_data)} total trials recorded by arduino!"
+                    )
             else:
-                # Convert to switch_after_trial: cumulative sum of user_block_trial_counts (excluding last block)
-                switch_after_trials = [sum(user_block_trial_counts[:n+1]) for n in range(len(user_block_trial_counts) - 1)]
-                logger.info(f"Converted barrier_switch_trial_counts {user_block_trial_counts} to "
-                            f"switch_after_trials {switch_after_trials}")
-                trial_data, block_data = reassign_block_boundaries(trial_data, block_data, switch_after_trials, logger)
+                # Convert trials per block to switch_after_trials (which trial_in_session marks the barrier switch)
+                switch_after_trials = [sum(user_block_trial_counts[:n+1]) 
+                                       for n in range(len(user_block_trial_counts) - 1)]
+                trial_data, block_data = reassign_block_boundaries(
+                    trial_data, block_data, switch_after_trials, maze_config_strings, logger
+                )
+    else:
+        # No reassignment: assign maze configurations to arduino block_data directly
+        for block, maze_str in zip(block_data, maze_config_strings):
+            block["maze_configuration"] = maze_str
+        logger.debug(f"Maze configurations: {[block['maze_configuration'] for block in block_data]}")
+
+    # Plot maze configurations for each block (after any reassignment so the plot reflects final block structure)
+    plot_maze_configurations(block_data=block_data, fig_dir=fig_dir)
 
     # Do some checks on trial and block data before adding to the NWB
     logger.debug("Validating trial and block data...")

--- a/src/jdb_to_nwb/convert_behavior.py
+++ b/src/jdb_to_nwb/convert_behavior.py
@@ -548,6 +548,51 @@ def validate_trial_and_block_data(trial_data: list, block_data: list, logger):
     logger.debug(f"The number of trials in each block sums to the total number of trials {len(trial_data)}")
 
 
+def reassign_block_boundaries(trial_data, block_data, switch_after_trials, logger):
+    """
+    Re-assign which trials belong to which block based on user-specified switch trial numbers.
+    Used when the arduino's block detection doesn't match when barriers were actually switched.
+
+    Args:
+    switch_after_trials (list[int]): Trial numbers after which the block switched.
+        For N blocks, there should be N-1 entries.
+        e.g. [42, 85] means block 1 = trials 1-42, block 2 = trials 43-85, block 3 = trials 86+
+    """
+    n_blocks = len(block_data)
+    if len(switch_after_trials) != n_blocks - 1:
+        logger.error(f"Expected {n_blocks - 1} switch point(s) for {n_blocks} blocks, "
+                     f"got {len(switch_after_trials)}: {switch_after_trials}")
+        raise ValueError(f"Expected {n_blocks - 1} switch point(s) for {n_blocks} blocks, "
+                         f"got {len(switch_after_trials)}")
+
+    logger.info(f"Reassigning block boundaries based on user-specified switch times: "
+                f"blocks switch after trials {switch_after_trials}")
+
+    # Re-assign block and trial_within_block for each trial
+    # trial_data is ordered by trial_within_session, so we can slice directly
+    boundaries = [0] + list(switch_after_trials) + [len(trial_data)]
+    for block_idx, (start, end) in enumerate(zip(boundaries, boundaries[1:])):
+        block_num = block_idx + 1
+        for trial_within_block, trial in enumerate(trial_data[start:end], start=1):
+            if trial['block'] != block_num:
+                logger.info(f"Reassigning trial {trial['trial_within_session']} "
+                            f"from block {trial['block']} to block {block_num}")
+            trial['block'] = block_num
+            trial['trial_within_block'] = trial_within_block
+
+    # Rebuild block start/end times and num_trials to match the new trial assignments
+    for block in block_data:
+        trials_in_block = [t for t in trial_data if t['block'] == block['block']]
+        block['num_trials'] = len(trials_in_block)
+        block['start_time'] = trials_in_block[0]['start_time']
+        block['end_time'] = trials_in_block[-1]['end_time']
+    # Block end time = start time of the next block (same convention as align_data_to_visits)
+    for block, next_block in zip(block_data, block_data[1:]):
+        block['end_time'] = next_block['start_time']
+
+    return trial_data, block_data
+
+
 def add_behavior(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
     """Add trial and block data to the nwbfile"""
     print("Adding behavior...")
@@ -633,6 +678,37 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
 
     # Align visit times to photometry/ephys
     trial_data, block_data = align_data_to_visits(trial_data, block_data, metadata, logger)
+
+    # We sometimes move the barriers at a different time than the trial indicated by the arduino output
+    # (to avoid moving a barrier right next to the rat, etc.)
+    # Re-assign block boundaries accordingly if the user specified "barrier_switch_trial_counts" in metadata
+    # e.g. arduino output = 66/63/67/61 trials per block, user specifies [67, 62, 68, 60], so we update things
+    # so blocks switch after trials [67, 129, 197] instead of [66, 129, 196]
+    if "barrier_switch_trial_counts" in metadata.get("behavior", {}):
+        if session_type != "barrier change":
+            logger.warning("'barrier_switch_trial_counts' is set in metadata but this is not a barrier change session!")
+            logger.warning(
+                "Information in 'barrier_switch_trial_counts' will be ignored. This should only be set in barrier"
+                "change sessions when the true barrier switch trials do not match the printed arduino output."
+                )
+        else:
+            user_block_trial_counts = metadata["behavior"]["barrier_switch_trial_counts"]
+            # User must specify the number of trials in each block (e.g. something like [67, 62, 68, 60] for 4 blocks)
+            if len(user_block_trial_counts) != len(block_data):
+                logger.error(f"Expected {len(block_data)} values in 'barrier_switch_trial_counts' (one per block),"
+                             f"got {len(user_block_trial_counts)}: {user_block_trial_counts}")
+            # The total number of user-specified trials must sum to the number of trials recorded by arduino
+            if sum(user_block_trial_counts) != len(trial_data):
+                logger.error(
+                    f"barrier_switch_trial_counts {user_block_trial_counts} sums to {sum(user_block_trial_counts)} "
+                    f"trials, but there are {len(trial_data)} total trials recorded by arduino!"
+                    )
+            else:
+                # Convert to switch_after_trial: cumulative sum of user_block_trial_counts (excluding last block)
+                switch_after_trials = [sum(user_block_trial_counts[:n+1]) for n in range(len(user_block_trial_counts) - 1)]
+                logger.info(f"Converted barrier_switch_trial_counts {user_block_trial_counts} to "
+                            f"switch_after_trials {switch_after_trials}")
+                trial_data, block_data = reassign_block_boundaries(trial_data, block_data, switch_after_trials, logger)
 
     # Do some checks on trial and block data before adding to the NWB
     logger.debug("Validating trial and block data...")

--- a/src/jdb_to_nwb/convert_behavior.py
+++ b/src/jdb_to_nwb/convert_behavior.py
@@ -639,6 +639,12 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
     trial_data, block_data = parse_arduino_text(arduino_text, arduino_timestamps, logger)
     logger.info(f"There are {len(block_data)} blocks and {len(trial_data)} trials")
 
+    # Save original arduino visit times for alignment before we re-align to photometry/ephys
+    arduino_visit_times = [trial['beam_break_start'] for trial in trial_data]
+
+    # Align visit times to photometry/ephys
+    trial_data, block_data = align_data_to_visits(trial_data, block_data, metadata, logger)
+
     # Use block data to determine if this is a probability change or barrier change session
     session_type = determine_session_type(block_data)
     for block in block_data:
@@ -694,12 +700,6 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
                 f"There are {len(block_data)} blocks but {len(maze_configurations)} mazes "
                 f"in the maze configuration file (expected {n_expected})."
             )
-
-    # Save original arduino visit times for alignment before we re-align to photometry/ephys
-    arduino_visit_times = [trial['beam_break_start'] for trial in trial_data]
-
-    # Align visit times to photometry/ephys
-    trial_data, block_data = align_data_to_visits(trial_data, block_data, metadata, logger)
 
     # Re-assign block boundaries accordingly if the user specified "barrier_shift_trial_counts" in metadata
     # e.g. arduino output = 66/63/67/61 trials per block, user specifies [67, 62, 68, 60], so we update things

--- a/tests/test_convert_behavior.py
+++ b/tests/test_convert_behavior.py
@@ -112,9 +112,9 @@ def test_convert_behavior(dummy_logger):
     assert trial_blocks[134] == 3  # trial 135 is block 3
 
 
-def test_barrier_switch_trial_counts(dummy_logger):
+def test_barrier_shift_trial_counts(dummy_logger):
     """
-    Test that barrier_switch_trial_counts in metadata correctly re-assigns block boundaries.
+    Test that barrier_shift_trial_counts in metadata correctly re-assigns block boundaries.
 
     The test session has blocks with 68/66/54 trials (188 trials total).
     We specify [69, 64, 55] as the user-specified trial counts per block (must sum to 188).
@@ -124,7 +124,7 @@ def test_barrier_switch_trial_counts(dummy_logger):
     metadata["behavior"]["arduino_text_file_path"] = "tests/test_data/behavior/arduinoraw0.txt"
     metadata["behavior"]["arduino_timestamps_file_path"] = "tests/test_data/behavior/ArduinoStamps0.csv"
     metadata["behavior"]["maze_configuration_file_path"] = "tests/test_data/behavior/barriers.txt"
-    metadata["behavior"]["barrier_switch_trial_counts"] = [69, 64, 55]
+    metadata["behavior"]["barrier_shift_trial_counts"] = [69, 64, 55]
 
     nwbfile = NWBFile(
         session_description="Mock session",
@@ -162,14 +162,14 @@ def test_barrier_switch_trial_counts(dummy_logger):
     assert trial_blocks[133] == 3  # trial 134 is block 3
 
 
-def test_barrier_switch_wrong_trial_sum(dummy_logger):
-    """If barrier_switch_trial_counts doesn't sum to total trials, raise ValueError."""
+def test_barrier_shift_wrong_trial_sum(dummy_logger):
+    """If barrier_shift_trial_counts doesn't sum to total trials, raise ValueError."""
     metadata = {}
     metadata["behavior"] = {}
     metadata["behavior"]["arduino_text_file_path"] = "tests/test_data/behavior/arduinoraw0.txt"
     metadata["behavior"]["arduino_timestamps_file_path"] = "tests/test_data/behavior/ArduinoStamps0.csv"
     metadata["behavior"]["maze_configuration_file_path"] = "tests/test_data/behavior/barriers.txt"
-    metadata["behavior"]["barrier_switch_trial_counts"] = [70, 64, 55]  # sums to 189, not 188
+    metadata["behavior"]["barrier_shift_trial_counts"] = [70, 64, 55]  # sums to 189, not 188
 
     nwbfile = NWBFile(
         session_description="Mock session",
@@ -182,7 +182,7 @@ def test_barrier_switch_wrong_trial_sum(dummy_logger):
         add_behavior(nwbfile=nwbfile, metadata=metadata, logger=dummy_logger)
 
 
-def test_barrier_switch_wrong_maze_count(dummy_logger, tmp_path):
+def test_barrier_shift_wrong_maze_count(dummy_logger, tmp_path):
     """If maze config file has the wrong number of mazes for the user-specified block count, raise ValueError."""
 
     metadata = {}
@@ -190,7 +190,7 @@ def test_barrier_switch_wrong_maze_count(dummy_logger, tmp_path):
     metadata["behavior"]["arduino_text_file_path"] = "tests/test_data/behavior/arduinoraw0.txt"
     metadata["behavior"]["arduino_timestamps_file_path"] = "tests/test_data/behavior/ArduinoStamps0.csv"
     metadata["behavior"]["maze_configuration_file_path"] = "tests/test_data/behavior/barriers.txt"
-    metadata["behavior"]["barrier_switch_trial_counts"] = [69, 64, 30, 25]  # expects 4 mazes, file has 3
+    metadata["behavior"]["barrier_shift_trial_counts"] = [69, 64, 30, 25]  # expects 4 mazes, file has 3
 
     nwbfile = NWBFile(
         session_description="Mock session",

--- a/tests/test_convert_behavior.py
+++ b/tests/test_convert_behavior.py
@@ -1,3 +1,4 @@
+import pytest
 from datetime import datetime
 from dateutil import tz
 from pynwb import NWBFile
@@ -81,10 +82,11 @@ def test_convert_behavior(dummy_logger):
     assert len(nwbfile.intervals["block"].start_time) == 3 # there are 3 blocks in this session
     # Check block data
     assert nwbfile.intervals["block"].num_trials[0] == 68
-    assert nwbfile.intervals["block"].maze_configuration[0] == "11,12,14,15,18,22,29,31,35,45", (
-        f"Maze configuration {nwbfile.intervals['block'].maze_configuration[0]} "
-        f"did not match expected '11,12,14,15,18,22,29,31,35,45'"
-    )
+    assert nwbfile.intervals["block"].num_trials[1] == 66
+    assert nwbfile.intervals["block"].num_trials[2] == 54
+    assert nwbfile.intervals["block"].maze_configuration[0] == "11,12,14,15,18,22,29,31,35,45"
+    assert nwbfile.intervals["block"].maze_configuration[1] == "11,12,14,15,18,20,22,29,31,45"
+    assert nwbfile.intervals["block"].maze_configuration[2] == "11,12,14,15,20,29,31,36,45"
     assert nwbfile.intervals["block"].pA[0] == 10
     assert nwbfile.intervals["block"].pB[0] == 50
     assert nwbfile.intervals["block"].pC[0] == 90
@@ -100,3 +102,102 @@ def test_convert_behavior(dummy_logger):
         f"did not match expected columns {expected_trial_columns}"
     )
     assert len(nwbfile.trials.start_time) == 188 # there are 188 trials in this session
+
+    # Check that block boundaries are correct: 
+    # block 1 = trials 1-68, block 2 = 69-134, block 3 = 135-188
+    trial_blocks = nwbfile.trials["block"].data[:]
+    assert trial_blocks[67] == 1  # trial 68 is block 1
+    assert trial_blocks[68] == 2  # trial 69 is block 2
+    assert trial_blocks[133] == 2  # trial 134 is block 2
+    assert trial_blocks[134] == 3  # trial 135 is block 3
+
+
+def test_barrier_switch_trial_counts(dummy_logger):
+    """
+    Test that barrier_switch_trial_counts in metadata correctly re-assigns block boundaries.
+
+    The test session has blocks with 68/66/54 trials (188 trials total).
+    We specify [69, 64, 55] as the user-specified trial counts per block (must sum to 188).
+    """
+    metadata = {}
+    metadata["behavior"] = {}
+    metadata["behavior"]["arduino_text_file_path"] = "tests/test_data/behavior/arduinoraw0.txt"
+    metadata["behavior"]["arduino_timestamps_file_path"] = "tests/test_data/behavior/ArduinoStamps0.csv"
+    metadata["behavior"]["maze_configuration_file_path"] = "tests/test_data/behavior/barriers.txt"
+    metadata["behavior"]["barrier_switch_trial_counts"] = [69, 64, 55]
+
+    nwbfile = NWBFile(
+        session_description="Mock session",
+        session_start_time=datetime.now(tz.tzlocal()),
+        identifier="mock_session",
+    )
+
+    add_behavior(nwbfile=nwbfile, metadata=metadata, logger=dummy_logger)
+
+    # Total trials should be unchanged
+    assert len(nwbfile.trials.start_time) == 188
+
+    # Actual block counts: 69 / 64 / 55
+    assert nwbfile.intervals["block"].num_trials[0] == 69   # trials 1-69
+    assert nwbfile.intervals["block"].num_trials[1] == 64   # trials 70-133
+    assert nwbfile.intervals["block"].num_trials[2] == 55   # trials 134-188
+
+    # Maze configurations should still be in the original block order from the barriers file
+    assert nwbfile.intervals["block"].maze_configuration[0] == "11,12,14,15,18,22,29,31,35,45"
+    assert nwbfile.intervals["block"].maze_configuration[1] == "11,12,14,15,18,20,22,29,31,45"
+    assert nwbfile.intervals["block"].maze_configuration[2] == "11,12,14,15,20,29,31,36,45"
+
+    # Reward probabilities should be the same for all blocks (barrier change session)
+    for i in range(3):
+        assert nwbfile.intervals["block"].pA[i] == 10
+        assert nwbfile.intervals["block"].pB[i] == 50
+        assert nwbfile.intervals["block"].pC[i] == 90
+
+    # Check that block boundaries are correct: 
+    # block 1 = trials 1-69, block 2 = 70-133, block 3 = 134-188
+    trial_blocks = nwbfile.trials["block"].data[:]
+    assert trial_blocks[68] == 1   # trial 69 is block 1
+    assert trial_blocks[69] == 2   # trial 70 is block 2
+    assert trial_blocks[132] == 2  # trial 133 is block 2
+    assert trial_blocks[133] == 3  # trial 134 is block 3
+
+
+def test_barrier_switch_wrong_trial_sum(dummy_logger):
+    """If barrier_switch_trial_counts doesn't sum to total trials, raise ValueError."""
+    metadata = {}
+    metadata["behavior"] = {}
+    metadata["behavior"]["arduino_text_file_path"] = "tests/test_data/behavior/arduinoraw0.txt"
+    metadata["behavior"]["arduino_timestamps_file_path"] = "tests/test_data/behavior/ArduinoStamps0.csv"
+    metadata["behavior"]["maze_configuration_file_path"] = "tests/test_data/behavior/barriers.txt"
+    metadata["behavior"]["barrier_switch_trial_counts"] = [70, 64, 55]  # sums to 189, not 188
+
+    nwbfile = NWBFile(
+        session_description="Mock session",
+        session_start_time=datetime.now(tz.tzlocal()),
+        identifier="mock_session",
+    )
+
+    # Should error for wrong number of total trials
+    with pytest.raises(ValueError):
+        add_behavior(nwbfile=nwbfile, metadata=metadata, logger=dummy_logger)
+
+
+def test_barrier_switch_wrong_maze_count(dummy_logger, tmp_path):
+    """If maze config file has the wrong number of mazes for the user-specified block count, raise ValueError."""
+
+    metadata = {}
+    metadata["behavior"] = {}
+    metadata["behavior"]["arduino_text_file_path"] = "tests/test_data/behavior/arduinoraw0.txt"
+    metadata["behavior"]["arduino_timestamps_file_path"] = "tests/test_data/behavior/ArduinoStamps0.csv"
+    metadata["behavior"]["maze_configuration_file_path"] = "tests/test_data/behavior/barriers.txt"
+    metadata["behavior"]["barrier_switch_trial_counts"] = [69, 64, 30, 25]  # expects 4 mazes, file has 3
+
+    nwbfile = NWBFile(
+        session_description="Mock session",
+        session_start_time=datetime.now(tz.tzlocal()),
+        identifier="mock_session",
+    )
+
+    # Should error for wrong number of maze configs
+    with pytest.raises(ValueError):
+        add_behavior(nwbfile=nwbfile, metadata=metadata, logger=dummy_logger)


### PR DESCRIPTION
Resolves #76 and #109

Add metadata field `barrier_shift_trial_counts` so the user can specify the actual number of trials in each block for barrier shift sessions, if the barriers were moved at a different time than specified by the arduino (e.g. to avoid moving a barrier right next to the rat).

The values must sum to the total number of trials in the session. For example, if the arduino output has 3 blocks with 68/66/54 trials, but the first barrier switch happened one trial late, specify `[69, 65, 54]`. 

You can use this to change the number of blocks from what was recorded by arduino, as long as number of mazes in the maze configuration file (barriers.txt) matches the number of blocks here. For example, if arduino recorded 68/66/67/2 (e.g. you didn't stop the recording in time, but didn't shift the barrier at the end), you could specify 68/66/69 and the 3 mazes you actually used to end up with 3 blocks (absorbing the 2-trial 4th block into the end of block 3).

This field will be ignored in probability change sessions. 

This PR also updates tests for this, adds additional logging for this case, and updates `metadata_fully_explained.yaml`.