### PR TITLE
Update minimum pin of hex-maze-neuro version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "ffmpeg-python",
     "tables",  # used by pandas to read HDF5 files
     "opencv-python",
-    "hex-maze-neuro",
+    "hex-maze-neuro >= 1.1.2",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Update pin so `pip install -e .` installs an up-to-date version of `hex-maze-neuro` (maze plots are more beautiful now)