### PR TITLE
Adjust photometry test tolerances for small floating point differences across platforms

### DIFF
--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -1221,8 +1221,10 @@ def test_apply_highpass_filter_gach(ppd_gach_rda_ref):
         ("ratio_lowpass", "ratio_highpass"),
     ]:
         result = apply_highpass_filter(ppd_gach_rda_ref[lowpass_key], sampling_rate=sampling_rate)
+        # Butterworth filter accumulation order varies across scipy versions/platforms (~1e-10 diffs),
+        # so use atol=1e-9 for GHA compatibility (passes at atol=1e-10 locally on Steph's Mac)
         np.testing.assert_allclose(
-            result, ppd_gach_rda_ref[highpass_key], atol=1e-10,
+            result, ppd_gach_rda_ref[highpass_key], atol=1e-9,
             err_msg=f"Highpass filter mismatch for {lowpass_key}",
         )
 
@@ -1285,8 +1287,10 @@ def test_process_single_signal_gach_ratiometric(ppd_gach_rda_ref, dummy_logger):
         result["smoothed"], ppd_gach_rda_ref["ratio_lowpass"], atol=1e-10,
         err_msg="Lowpass-smoothed ratio mismatch",
     )
+    # Butterworth filter accumulation order varies across scipy versions/platforms (~1e-10 diffs),
+    # so use atol=1e-9 for GHA compatibility (passes at atol=1e-10 locally on Steph's Mac)
     np.testing.assert_allclose(
-        result["baseline_subtracted"], ppd_gach_rda_ref["ratio_highpass"], atol=1e-10,
+        result["baseline_subtracted"], ppd_gach_rda_ref["ratio_highpass"], atol=1e-9,
         err_msg="Highpass baseline-subtracted ratio mismatch",
     )
     # np.mean/std use platform-specific SIMD summation (AVX/SSE on x86 vs NEON on ARM),

--- a/tests/test_convert_photometry.py
+++ b/tests/test_convert_photometry.py
@@ -1294,10 +1294,11 @@ def test_process_single_signal_gach_ratiometric(ppd_gach_rda_ref, dummy_logger):
         err_msg="Highpass baseline-subtracted ratio mismatch",
     )
     # np.mean/std use platform-specific SIMD summation (AVX/SSE on x86 vs NEON on ARM),
-    # producing ~1e-8 differences in z-score when computed from a recomputed (vs stored) array.
-    # We'll test with atol=1e-7 so tests pass on Github actions.
+    # producing differences in z-score when computed from a recomputed (vs stored) array.
+    # The highpass filter also accumulates ~1e-9 platform differences which compound here.
+    # Max observed diff on GHA: ~1.75e-7, so use atol=1e-6 for GHA compatibility.
     # For the record, on Stephanie's Mac, tests pass locally with atol=1e-10
     np.testing.assert_allclose(
-        result["normalized"], ppd_gach_rda_ref["ratio_zscored"], atol=1e-7,
+        result["normalized"], ppd_gach_rda_ref["ratio_zscored"], atol=1e-6,
         err_msg="Z-scored ratio mismatch",
     )


### PR DESCRIPTION
Adjust tolerances from `atol=1e-10` to `1e-9` because some of our photometry tests are failing due to tiny floating point differences

They pass with high tolerances on my local machine i promise !!!