### PR TITLE
Use helpers log_and_print and add_associated_file

### DIFF
--- a/src/jdb_to_nwb/convert.py
+++ b/src/jdb_to_nwb/convert.py
@@ -7,10 +7,9 @@ import shutil
 
 from pynwb import NWBFile, NWBHDF5IO
 from pynwb.file import Subject
-from ndx_franklab_novela import AssociatedFiles
 
 from . import __version__
-from .utils import to_datetime, setup_logger
+from .utils import to_datetime, setup_logger, log_and_print, add_associated_file
 from .convert_video import add_video
 from .convert_position import add_position
 from .convert_raw_ephys import add_raw_ephys
@@ -69,17 +68,15 @@ def set_default_metadata(metadata, logger):
     # Set defaults if these fields are missing
     if "institution" not in metadata:
         metadata["institution"] = "University of California, San Francisco"
-        logger.warning("No 'institution' found in metadata, "
-                       "setting to default 'University of California, San Francisco'")
-        print("No 'institution' found in metadata, setting to default 'University of California, San Francisco'")
+        log_and_print(logger, "No 'institution' found in metadata, "
+                      "setting to default 'University of California, San Francisco'", level="warning")
     if "lab" not in metadata:
         metadata["lab"] = "Berke Lab"
-        logger.warning("No 'lab' found in metadata, setting to default 'Berke Lab'")
-        print("No 'lab' found in metadata, setting to default 'Berke Lab'")
+        log_and_print(logger, "No 'lab' found in metadata, setting to default 'Berke Lab'", level="warning")
     if "experiment_description" not in metadata:
         metadata["experiment_description"] = "Hex maze task"
-        logger.warning("No 'experiment_description' found in metadata, setting to default 'Hex maze task'")
-        print("No 'experiment_description' found in metadata, setting to default 'Hex maze task'")
+        log_and_print(logger, "No 'experiment_description' found in metadata, setting to default 'Hex maze task'",
+                      level="warning")
 
 
 def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
@@ -110,10 +107,8 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
     debug_log_file = Path(log_dir) / f"{session_id}_debug_logs.log"
     logger = setup_logger("conversion_log", info_log_file, warning_log_file, debug_log_file)
 
-    logger.info(f"Starting conversion for session_id {session_id}")
-    logger.info(f"Using source script jdb_to_nwb {__version__}")
-    print(f"Starting conversion for session_id {session_id}")
-    print(f"Using source script jdb_to_nwb {__version__}")
+    log_and_print(logger, f"Starting conversion for session_id {session_id}", level="info")
+    log_and_print(logger, f"Using source script jdb_to_nwb {__version__}", level="info")
 
     # Save a copy of the metadata file to the logging directory
     metadata_copy_file_path = Path(log_dir) / f"{session_id}_metadata.yaml"
@@ -204,9 +199,6 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
         handler.flush()
 
     # Save metadata YAML and log files as AssociatedFiles objects in the NWB so the NWB is self-contained
-    if "associated_files" not in nwbfile.processing:
-        nwbfile.create_processing_module(name="associated_files", description="Contains all associated files")
-
     files_to_embed = [
         ("metadata_yaml",  "Metadata YAML file used to create this NWB file", metadata_copy_file_path),
         ("info_log",       "Info-level conversion log",                         info_log_file),
@@ -216,22 +208,14 @@ def create_nwbs(metadata_file_path: Path, output_nwb_dir: Path):
     for name, description, file_path in files_to_embed:
         with open(file_path, "r") as f:
             content = f.read()
-        nwbfile.processing["associated_files"].add(AssociatedFiles(
-            name=name,
-            description=description,
-            content=content,
-            task_epochs="0",
-        ))
-        logger.info(f"Saved {file_path.name} as AssociatedFiles object '{name}' in NWB")
+        add_associated_file(nwbfile, name=name, description=description, content=content, logger=logger)
 
-    print("Writing file...")
-    logger.info("Writing file...")
+    log_and_print(logger, "Writing file...", level="info")
     output_nwb_file_path = Path(output_nwb_dir) / f"{session_id}.nwb"
     with NWBHDF5IO(output_nwb_file_path, mode="w") as io:
         io.write(nwbfile)
 
-    print(f"NWB file created successfully at {output_nwb_file_path}")
-    logger.info(f"NWB file created successfully at {output_nwb_file_path}")
+    log_and_print(logger, f"NWB file created successfully at {output_nwb_file_path}", level="info")
 
 
 def cli():

--- a/src/jdb_to_nwb/convert_behavior.py
+++ b/src/jdb_to_nwb/convert_behavior.py
@@ -6,7 +6,7 @@ import numpy as np
 from pathlib import Path
 from pynwb import NWBFile
 from hdmf.common.table import DynamicTable, VectorData
-from ndx_franklab_novela import AssociatedFiles
+from .utils import log_and_print, add_associated_file
 from .timestamps_alignment import trim_sync_pulses, align_via_interpolation, handle_timestamps_reset
 from .plotting.plot_behavior import (
     plot_maze_configurations, 
@@ -625,8 +625,7 @@ def reassign_block_boundaries(trial_data, block_data, switch_after_trials, maze_
 
 def add_behavior(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
     """Add trial and block data to the nwbfile"""
-    print("Adding behavior...")
-    logger.info("Adding behavior...")
+    log_and_print(logger, "Adding behavior...", level="info")
 
     # Get file paths for behavior from metadata file
     arduino_text_file_path = metadata["behavior"]["arduino_text_file_path"]
@@ -901,34 +900,16 @@ def add_behavior(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
     )
     nwbfile.processing["tasks"].add(task)
 
-    # Save the raw arduino text and timestamps as strings to be used to create AssociatedFiles objects
-    logger.debug("Saving the arduino text file and arduino timestamps file as AssociatedFiles objects")
+    # Save the raw arduino text and timestamps as AssociatedFiles objects in the nwb
     with open(arduino_text_file_path, "r") as arduino_text_file:
         raw_arduino_text = arduino_text_file.read()
     with open(arduino_timestamps_file_path, "r") as arduino_timestamps_file:
         raw_arduino_timestamps = arduino_timestamps_file.read()
 
-    raw_arduino_text_file = AssociatedFiles(
-        name="arduino_text",
-        description="Raw arduino text",
-        content=raw_arduino_text,
-        task_epochs="0",  # Berke Lab only has one epoch (session) per day
-    )
-    raw_arduino_timestamps_file = AssociatedFiles(
-        name="arduino_timestamps",
-        description="Raw arduino timestamps",
-        content=raw_arduino_timestamps,
-        task_epochs="0",  # Berke Lab only has one epoch (session) per day
-    )
-
-    # If it doesn't exist already, make a processing module for associated files
-    if "associated_files" not in nwbfile.processing:
-        logger.debug("Creating nwb processing module for associated files")
-        nwbfile.create_processing_module(name="associated_files", description="Contains all associated files")
-
-    # Add arduino text and timestamps to the NWB as associated files
-    nwbfile.processing["associated_files"].add(raw_arduino_text_file)
-    nwbfile.processing["associated_files"].add(raw_arduino_timestamps_file)
+    add_associated_file(nwbfile, name="arduino_text", description="Raw arduino text",
+                        content=raw_arduino_text, logger=logger)
+    add_associated_file(nwbfile, name="arduino_timestamps", description="Raw arduino timestamps",
+                        content=raw_arduino_timestamps, logger=logger)
 
     # Return photometry start in arduino time for video/DLC and behavioral alignment with photometry
     return {'photometry_start_in_arduino_time': photometry_start_in_arduino_time, 'port_visits': arduino_visit_times}

--- a/src/jdb_to_nwb/convert_photometry.py
+++ b/src/jdb_to_nwb/convert_photometry.py
@@ -32,6 +32,7 @@ from .plotting.plot_photometry import (
     plot_signal_correlation,
     plot_photometry_signals,
 )
+from .utils import log_and_print
 
 # Get the location of the resources directory when the package is installed from pypi
 __location_of_this_file = Path(files(__name__))
@@ -1180,8 +1181,7 @@ def write_photometry_to_nwb(nwbfile, bundle, processing_results, logger):
 
     Returns a dict with keys: sampling_rate, port_visits, photometry_start, signals_to_plot
     """
-    print("Adding photometry signals to NWB...")
-    logger.info("Adding photometry signals to NWB...")
+    log_and_print(logger, "Adding photometry signals to NWB...", level="info")
 
     # Write raw signals (one per wavelength in the bundle, written once)
     written_raw_wavelengths = set()
@@ -1625,13 +1625,12 @@ def add_photometry(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
     """
 
     if "photometry" not in metadata:
-        print("No photometry metadata found for this session. Skipping photometry conversion.")
-        logger.info("No photometry metadata found for this session. Skipping photometry conversion.")
+        log_and_print(logger, "No photometry metadata found for this session. Skipping photometry conversion.", 
+                      level="info")
         return {}
 
     # 1. Add photometry metadata to NWB
-    print("Adding photometry metadata to NWB...")
-    logger.info("Adding photometry metadata to NWB...")
+    log_and_print(logger, "Adding photometry metadata to NWB...", level="info")
     add_photometry_metadata(nwbfile, metadata, logger)
 
     # 2. Load photometry signals into PhotometrySignalBundle

--- a/src/jdb_to_nwb/convert_position.py
+++ b/src/jdb_to_nwb/convert_position.py
@@ -6,6 +6,7 @@ from pynwb.behavior import Position
 from scipy.interpolate import interp1d
 from .timestamps_alignment import align_via_interpolation, handle_timestamps_reset
 from .plotting.plot_combined import plot_rat_position_heatmap, plot_rat_position_by_trial
+from .utils import log_and_print
 
 
 def read_dlc(deeplabcut_file_path, pixels_per_cm, logger, likelihood_cutoff=0.9, cam_fps=15):
@@ -31,8 +32,7 @@ def read_dlc(deeplabcut_file_path, pixels_per_cm, logger, likelihood_cutoff=0.9,
     
     # The bodypart names are stored as second-level columns
     body_part_names = set(dlc_position.columns.get_level_values('bodyparts'))
-    print(f"Found DeepLabCut bodyparts: {body_part_names}")
-    logger.info(f"Found DeepLabCut bodyparts: {body_part_names}")
+    log_and_print(logger, f"Found DeepLabCut bodyparts: {body_part_names}", level="info")
 
     body_part_dfs = []
     for body_part in list(body_part_names):
@@ -175,8 +175,7 @@ def add_position_to_nwb(nwbfile: NWBFile, position_data: list[tuple], pixels_per
 
     # Add x,y position to the nwb as a SpatialSeries for each tracked body part
     for body_part_name, body_part_position_df in position_data:
-        logger.info(f"Adding position data for {body_part_name} to the nwb...")
-        print(f"Adding position data for {body_part_name} to the nwb...")
+        log_and_print(logger, f"Adding position data for {body_part_name} to the nwb...", level="info")
         position.create_spatial_series(
             name=f"{body_part_name}_position",
             description="xloc, yloc",
@@ -223,20 +222,17 @@ def add_position(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
     # It is ok if we have video field in metadata but not DLC data
     # The user may wish to only convert the raw video file and do position tracking later
     if "dlc_path" not in metadata["video"]:
-        print("No DeepLabCut (DLC) metadata found for this session. Skipping DLC conversion.")
-        logger.warning("No DeepLabCut (DLC) metadata found for this session. Skipping DLC conversion.")
+        log_and_print(logger, "No DeepLabCut (DLC) metadata found for this session. Skipping DLC conversion.",
+                      level="warning")
         return
 
     # If we do have dlc_path, we must also have video timestamps for DLC conversion
     if "video_timestamps_file_path" not in metadata["video"]:
-        logger.error("Video subfield 'video_timestamps_file_path' not found in metadata. \n"
+        log_and_print(logger,
+            "Video subfield 'video_timestamps_file_path' not found in metadata. \n"
             "This is required along with 'dlc_path' for DLC position conversion. \n"
-            "If you do not wish to convert DeepLabCut data, please remove field 'dlc_path' from metadata."
-            )
-        print("Video subfield 'video_timestamps_file_path' not found in metadata. \n"
-            "This is required along with 'dlc_path' for DLC position conversion. \n"
-            "If you do not wish to convert DeepLabCut data, please remove field 'dlc_path' from metadata."
-            )
+            "If you do not wish to convert DeepLabCut data, please remove field 'dlc_path' from metadata.",
+            level="error")
         return
 
     # At this point, pixels_per_cm must exist in metadata. If it did not exist, 
@@ -282,8 +278,7 @@ def add_position(nwbfile: NWBFile, metadata: dict, logger, fig_dir=None):
             logger.info("No ground truth port visits found, keeping original position (video) timestamps.")
             true_video_timestamps = video_timestamps_seconds
 
-    print("Adding position data from DeepLabCut...")
-    logger.info("Adding position data from DeepLabCut...")
+    log_and_print(logger, "Adding position data from DeepLabCut...", level="info")
 
     # Metadata should include the full path to the DLC h5 file
     # e.g. Behav_Vid0DLC_resnet50_Triangle_Maze_EphysDec7shuffle1_800000.h5

--- a/src/jdb_to_nwb/convert_raw_ephys.py
+++ b/src/jdb_to_nwb/convert_raw_ephys.py
@@ -1372,7 +1372,7 @@ def add_raw_ephys(
     """
 
     if "ephys" not in metadata:
-        log_and_print(logger, "No ephys metadata found for this session. Skipping ephys conversion.")
+        log_and_print(logger, "No ephys metadata found for this session. Skipping ephys conversion.", level="info")
         return {}
 
     # If we do have "ephys" in metadata, check for the required keys.
@@ -1390,7 +1390,7 @@ def add_raw_ephys(
         )
         return {}
 
-    log_and_print(logger, "Adding raw ephys...")
+    log_and_print(logger, "Adding raw ephys...", level="info")
     openephys_folder_path = metadata["ephys"]["openephys_folder_path"]
 
     # Get Open Ephys start time as datetime object based on the time specified in the folder name
@@ -1442,7 +1442,7 @@ def add_raw_ephys(
     #   pulse_high_threshold is the raw int16 value above which the port visit channel is considered "high"
     #   exclude_channel_names are neural channels to drop from the ElectricalSeries (Berke ECoG screws)
     if probe_metadata["name"] in BERKE_LAB_PROBES:
-        log_and_print(logger, f"Processing '{probe_metadata['name']}' as a Berke Lab custom probe.")
+        log_and_print(logger, f"Processing '{probe_metadata['name']}' as a Berke Lab custom probe.", level="info")
 
         # Berke Lab probes require a per-session impedance file (used to mark bad channels)
         if "impedance_file_path" not in metadata["ephys"]:
@@ -1478,7 +1478,7 @@ def add_raw_ephys(
         exclude_channel_names = [row["open_ephys_channel_string"] for row in excluded_channels]
 
     else:
-        log_and_print(logger, f"Processing '{probe_metadata['name']}' as a Neuropixels probe.")
+        log_and_print(logger, f"Processing '{probe_metadata['name']}' as a Neuropixels probe.", level="info")
 
         # For Neuropixels (OneBox), port visits are recorded on a SEPARATE OneBox-ADC stream (its own
         # continuous.dat), not in the probe's continuous.dat. Find that ADC stream and read its params.
@@ -1537,7 +1537,7 @@ def add_raw_ephys(
                                                            sample_rate=port_visits_sample_rate,
                                                            logger=logger,
                                                            pulse_high_threshold=pulse_high_threshold)
-    log_and_print(logger, f"Open Ephys recorded {len(ephys_visit_times)} port visits.")
+    log_and_print(logger, f"Open Ephys recorded {len(ephys_visit_times)} port visits.", level="info")
     logger.debug(f"Open Ephys port visits: {ephys_visit_times}")
 
     # Convert the bonsai start time (seconds) to a number of samples in the probe's sample rate.
@@ -1673,5 +1673,5 @@ def add_raw_ephys(
         log_filename="structure.oebin",
     )
 
-    log_and_print(logger, "Finished adding raw ephys to the nwb.")
+    log_and_print(logger, "Finished adding raw ephys to the nwb.", level="info")
     return {"ephys_start": open_ephys_start, "port_visits": ephys_visit_times}

--- a/src/jdb_to_nwb/convert_spikes.py
+++ b/src/jdb_to_nwb/convert_spikes.py
@@ -1,19 +1,20 @@
 from .mdasortinginterface import MdaSortingInterface
 from pynwb import NWBFile
 
+from .utils import log_and_print
+
 
 def add_spikes(nwbfile: NWBFile, metadata: dict, logger):
-    
+
     if "ephys" not in metadata:
         return
-    
+
     if not ("mountain_sort_output_file_path" in metadata["ephys"] and "sampling_frequency" in metadata["ephys"]):
-        print("No spike sorting metadata found for this session. Skipping spike conversion.")
-        logger.info("No spike sorting metadata found for this session. Skipping spike conversion.")
+        log_and_print(logger, "No spike sorting metadata found for this session. Skipping spike conversion.", 
+                      level="info")
         return
 
-    print("Adding spikes...")
-    logger.info("Adding spikes...")
+    log_and_print(logger, "Adding spikes...", level="info")
     mountain_sort_output_file_path = metadata["ephys"]["mountain_sort_output_file_path"]
     sampling_frequency = metadata["ephys"]["sampling_frequency"]
 

--- a/src/jdb_to_nwb/convert_video.py
+++ b/src/jdb_to_nwb/convert_video.py
@@ -10,6 +10,8 @@ from pynwb import NWBFile
 from pynwb.image import ImageSeries
 from pynwb.behavior import BehavioralEvents
 from ndx_franklab_novela import CameraDevice
+
+from .utils import log_and_print
 from hdmf.common import DynamicTable
 from .timestamps_alignment import align_via_interpolation, handle_timestamps_reset
 from .plotting.plot_combined import plot_maze_on_video_frame
@@ -58,8 +60,8 @@ def add_hex_centroids(nwbfile: NWBFile, metadata: dict, logger):
         hex_centroids = pd.read_csv(hex_centroids_file)
         logger.debug(f"Found hex centroids file at '{hex_centroids_file}'")
     except FileNotFoundError:
-        logger.error(f"The file '{hex_centroids_file}' was not found! Skipping adding hex centroids.")
-        print(f"Error: The file '{hex_centroids_file}' was not found! Skipping adding hex centroids.")
+        log_and_print(logger, f"The file '{hex_centroids_file}' was not found! Skipping adding hex centroids.",
+                      level="error")
         return
 
     # Check that the hex centroids file is in the format we expect
@@ -164,8 +166,7 @@ def compress_avi_to_mp4(input_video_path, output_video_path, logger, crf=23, pre
             ffmpeg.input(str(input_video_path)).output(str(output_video_path), vcodec="libx264", crf=crf, preset=preset)
             .run(cmd=ffmpeg_exe, overwrite_output=True, capture_stdout=False, capture_stderr=True)
         )
-        logger.info(f"Compressed video at {input_video_path} to {output_video_path}")
-        print(f"Compressed video at {input_video_path} to {output_video_path}")
+        log_and_print(logger, f"Compressed video at {input_video_path} to {output_video_path}", level="info")
     except Exception as e:
         logger.error(f"An error occurred during video compression: {str(e)}")
         print("An error occurred during video compression:")
@@ -224,32 +225,32 @@ def add_video(nwbfile: NWBFile, metadata: dict, output_video_path, logger, fig_d
     metadata["pixels_per_cm"] = pixels_per_cm
 
     # Add camera once we ensure pixels_per_cm is in metadata
-    print("Adding camera...")
-    logger.info("Adding camera...")
+    log_and_print(logger, "Adding camera...", level="info")
     add_camera(nwbfile=nwbfile, metadata=metadata)
 
     # Now check if we actually have video data to add
     if "video" not in metadata:
-        print("No video metadata found for this session. Skipping video conversion.")
-        logger.warning("No video metadata found for this session. Skipping video conversion.")
+        log_and_print(logger, "No video metadata found for this session. Skipping video conversion.",
+                      level="warning")
         return None
 
     if "hex_centroids_file_path" in metadata["video"]:
         add_hex_centroids(nwbfile=nwbfile, metadata=metadata, logger=logger)
     else:
-        print("No subfield 'hex_centroids_file_path' found in video metadata! Skipping adding hex centroids.")
-        logger.warning("No subfield 'hex_centroids_file_path' found in video metadata! Skipping adding hex centroids.")
+        log_and_print(logger,
+                      "No subfield 'hex_centroids_file_path' found in video metadata! Skipping adding hex centroids.",
+                      level="warning")
 
     if "video_file_path" not in metadata["video"] or "video_timestamps_file_path" not in metadata["video"]:
-        print("Skipping video file conversion (requires both 'video_file_path' and 'video_timestamps_file_path')")
-        logger.warning("Skipping video file conversion "
-                       "(requires both 'video_file_path' and 'video_timestamps_file_path')")
+        log_and_print(logger,
+                      "Skipping video file conversion "
+                      "(requires both 'video_file_path' and 'video_timestamps_file_path')",
+                      level="warning")
         # Warn but don't raise an error here because it is technically ok for a user to specify the "video"
         # field in metadata but not the actual video data, because DLC (position) also lives under the video field
         return None
 
-    print("Adding video...")
-    logger.info("Adding video...")
+    log_and_print(logger, "Adding video...", level="info")
 
     # Get file paths for video from metadata file
     video_file_path = metadata["video"]["video_file_path"]
@@ -290,8 +291,7 @@ def add_video(nwbfile: NWBFile, metadata: dict, output_video_path, logger, fig_d
                  f"{np.array(true_video_timestamps) - np.array(video_timestamps_seconds)}")
 
     # Convert video from .avi to .mp4 and copy it to the nwb output directory
-    print("Compressing video from .avi to .mp4 and copying to nwb output directory...")
-    logger.info("Compressing video from .avi to .mp4 and copying to nwb output directory...")
+    log_and_print(logger, "Compressing video from .avi to .mp4 and copying to nwb output directory...", level="info")
     compress_avi_to_mp4(input_video_path=video_file_path, output_video_path=output_video_path, logger=logger)
 
     # Create nwb processing module for video files


### PR DESCRIPTION
My previous PR #218 added helper functions `log_and_print` and `add_associated_file` to clean things up
This is a follow-up to use these throughout the repo (so the other PR didn't touch non-ephys files)